### PR TITLE
Make airtable_scraper_service more robust to field name changes

### DIFF
--- a/app/namespaces/airtable_scraper/airtable_scraper_service.py
+++ b/app/namespaces/airtable_scraper/airtable_scraper_service.py
@@ -29,8 +29,8 @@ def get_formatted_json_records(records):
     renamed_cols = {}
     with open('app/utils/airtable_fields_config.json', 'r') as file:
         fields = json.load(file)
-        renamed_cols = {value[0]: value[1] for value in fields.values() if value[0] in df.columns}
-        reordered_cols = [value[1] for value in fields.values() if value[0] in df.columns]
+        renamed_cols = {value[0]: value[1] for value in fields.values() if value[0] in total_records_df.columns}
+        reordered_cols = [value[1] for value in fields.values() if value[0] in total_records_df.columns]
     total_records_df = total_records_df.rename(columns=renamed_cols)
     total_records_df = total_records_df[reordered_cols]
     total_records_df = total_records_df.replace({np.nan: None})


### PR DESCRIPTION
Refactor for loop that defines renamed_cols and reordered_cols into dict and list comprehensions, respectively
Add conditionals to this comprehensions, so that a given `value` is only added to the list if `value[0]` is in `df.columns` - that is, if renaming that column will work, and if getting that series from the DF won't throw a KeyError.