### PR TITLE
Allow empty filters to be passed in

### DIFF
--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -113,7 +113,9 @@ def get_filtered_records(filters=None, columns=None, start_date=None, end_date=N
     # Return all records if no filters are passed in
     if filters:
         def should_include(d, k, v):
-            if isinstance(d[k], str) and d[k] in v:
+            if len(v) == 0:
+                return True
+            elif isinstance(d[k], str) and d[k] in v:
                 return True
             elif isinstance(d[k], list) and set(d[k]).intersection(set(v)):
                 return True


### PR DESCRIPTION
- Allow filters in the form {filter_key: []} to be passed in for frontend convenience.
- If an empty filter is passed in, it should not be applied (i.e. should let all records pass)