### PR TITLE
Hotfix for the filter issue

### DIFF
--- a/app/namespaces/airtable_scraper/airtable_scraper_service.py
+++ b/app/namespaces/airtable_scraper/airtable_scraper_service.py
@@ -4,6 +4,7 @@ import logging
 import requests
 import pandas as pd
 import numpy as np
+import math
 
 from flask import current_app as app
 from app.utils import read_from_json, send_api_error_email, airtable_fields_config
@@ -139,9 +140,11 @@ def get_country_seroprev_summaries(records):
                 # Add number of estimates for that grade
                 estimate_grade_dict['n_estimates'] = n_estimates
 
+                minimum = records_for_grade.serum_pos_prevalence.min()
+                maximum = records_for_grade.serum_pos_prevalence.max()
                 # Add min and max seroprev estimates
-                estimate_grade_dict['min_estimate'] = records_for_grade.serum_pos_prevalence.min()
-                estimate_grade_dict['max_estimate'] = records_for_grade.serum_pos_prevalence.max()
+                estimate_grade_dict['min_estimate'] = minimum if not math.isnan(minimum) else None
+                estimate_grade_dict['max_estimate'] = maximum if not math.isnan(maximum) else None
             grades_seroprev_summaries_dict[grade] = estimate_grade_dict
         country_seroprev_summary_dict['seroprevalence_estimate_summary'] = grades_seroprev_summaries_dict
         study_counts_list.append(country_seroprev_summary_dict)


### PR DESCRIPTION
Prevent NaN values from being sent by the country_seroprev_summary endpoint. Send None's instead, which are JSON parseable