### PR TITLE
Fix parsing of datetimes coming from GMT timezone

### DIFF
--- a/app/utils/helper_funcs.py
+++ b/app/utils/helper_funcs.py
@@ -14,8 +14,13 @@ def validate_request_input_against_schema(input_payload, schema):
 def convert_start_end_dates(data):
     start_date = data.get('start_date')
     if start_date:
+        # Python's datetime module does not
+        # support ISO 8601 strings whose UTC offsets = Z (aka GMT or UK time)
+        # see https://stackoverflow.com/questions/127803/how-do-i-parse-an-iso-8601-formatted-date
+        start_date = start_date.replace("Z", "+00:00")
         start_date = datetime.fromisoformat(start_date).replace(tzinfo=None)
     end_date = data.get('end_date')
     if end_date:
+        end_date = end_date.replace("Z", "+00:00")
         end_date = datetime.fromisoformat(end_date).replace(tzinfo=None)
     return start_date, end_date


### PR DESCRIPTION
### The issue

When making requests to the backend that have a ```start_date``` or ```end_date``` parameter, the web client will pass in an ISO 8601 datetime string whose timezone information is based on settings configured on the user's machine.

Typically, a substring in the form "+05:00"  is featured at the end of ISO 8601 datetime strings. This represents the offset associated with the timezone that's currently being considered (e.g. this would mean that the user is in UTC+5). However, for UK timezones (UTC+0), it is possible for that substring to be 'Z' (representing zero offset) or '+00:00'. 

The problem is that Python's datetime module does not support ISO 8601 strings that have 'Z'. Thus, this PR fixes this issue by replacing 'Z' characters coming in from the frontend with '+00:00'.

### How to validate

1. Run the server locally on `architecture-v2`
2. Set your the timezone on your machine to UTC+0
3. Run the frontend locally and point it to your local server
4. Confirm that the frontend shows no data
5. Re-run the server, now on the branch `fix-uk-tz-issue`
6. Restart the frontend and point it to the server on the uk-tz branch
7. Confirm that the frontend now shows data