### PR TITLE
Add logging to meta analysis namespace, suppress stream logging

### DIFF
--- a/app/namespaces/meta_analysis/meta_analysis_controller.py
+++ b/app/namespaces/meta_analysis/meta_analysis_controller.py
@@ -23,6 +23,13 @@ class MetaAnalysis(Resource):
         if not json_input:
             return make_response({"message": "No input payload provided"}, 400)
 
+        # Log request info
+        logging.info("Endpoint Type: {type}, Endpoint Path: {path}, Arguments: {args}".format(
+            type=request.environ['REQUEST_METHOD'],
+            path=request.environ['PATH_INFO'],
+            args=dict(request.args),
+            payload=json_input))
+
         # Validate input payload
         payload, status_code = validate_request_input_against_schema(json_input, MetaSchema())
         if status_code != 200:

--- a/logging.cfg
+++ b/logging.cfg
@@ -13,6 +13,7 @@ qualname=root
 handlers=consoleHandler,fileHandler
 
 [handler_consoleHandler]
+level=ERROR
 class=StreamHandler
 formatter=consoleFormatter
 args=(sys.stdout,)


### PR DESCRIPTION
# Changelog
- Change StreamHandler level to "ERROR" to ensure only error messages are outputted to the console
- Add logging statements to the meta analysis endpoint

# How did I test?
- Ran the server locally and pointed a local version of the ST web client to it
- Navigated to the analyze tab and changed some filters
- Checked the logfile to ensure that the meta-analysis endpoint invocations were properly logged