### PR TITLE
Fix param parsing for research_fields and prioritize_estimates

### DIFF
--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -21,8 +21,8 @@ class Records(Resource):
         reverse = request.args.get('reverse', None, type=bool)
         page_index = request.args.get('page_index', None, type=int)
         per_page = request.args.get('per_page', None, type=int)
-        research_fields = request.args.get('research_fields', False, type=bool)
-        prioritize_estimates = request.args.get('prioritize_estimates', True, type=bool)
+        research_fields = False if request.args.get('research_fields', 'false', type=str) == 'false' else True
+        prioritize_estimates = True if request.args.get('prioritize_estimates', 'true', type=str) == 'true' else False
 
         # Log request info
         logging.info("Endpoint Type: {type}, Endpoint Path: {path}, Arguments: {args}".format(

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -21,8 +21,9 @@ class Records(Resource):
         reverse = request.args.get('reverse', None, type=bool)
         page_index = request.args.get('page_index', None, type=int)
         per_page = request.args.get('per_page', None, type=int)
-        research_fields = False if request.args.get('research_fields', 'false', type=str) == 'false' else True
-        prioritize_estimates = True if request.args.get('prioritize_estimates', 'true', type=str) == 'true' else False
+        research_fields = False if str.lower(request.args.get('research_fields', 'false', type=str)) == 'false' else True
+        prioritize_estimates = True if str.lower(request.args.get('prioritize_estimates', 'true', type=str)) == 'true' else False
+        print(research_fields)
 
         # Log request info
         logging.info("Endpoint Type: {type}, Endpoint Path: {path}, Arguments: {args}".format(

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -21,9 +21,10 @@ class Records(Resource):
         reverse = request.args.get('reverse', None, type=bool)
         page_index = request.args.get('page_index', None, type=int)
         per_page = request.args.get('per_page', None, type=int)
+
+        # Type must be string not bool, because bool evaluates to true for any non None value including False and True
         research_fields = False if str.lower(request.args.get('research_fields', 'false', type=str)) == 'false' else True
         prioritize_estimates = True if str.lower(request.args.get('prioritize_estimates', 'true', type=str)) == 'true' else False
-        print(research_fields)
 
         # Log request info
         logging.info("Endpoint Type: {type}, Endpoint Path: {path}, Arguments: {args}".format(


### PR DESCRIPTION
Previously we were setting the defaults of the research_fields and prioritize_estimates fields to be False and True respectively, and we set the type to be bool. But in python bool(True) = bool(False) = True because the value is set, so if you passed in research_fields = False it would still set the param to true (reverse logic for prioritize_estimates). I changed the param type to be a string and then manually set the bool val of the param based on the value of the string.