### PR TITLE
Add republic of congo's iso3 code

### DIFF
--- a/app/database_etl/country_iso3.json
+++ b/app/database_etl/country_iso3.json
@@ -54,5 +54,6 @@
     "Australia": "AUS",
     "Argentina": "ARG",
     "Armenia": "ARM",
-    "Romania": "ROU"
+    "Romania": "ROU",
+    "Republic of Congo": "COG"
 }


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

ETL cannot find the ISO3 code associated with the "Republic of Congo". This has lead to the following slack notification:

![image](https://user-images.githubusercontent.com/21212898/106395546-c7b7f000-63d0-11eb-9135-c6392ccb62c8.png)

## Please link the Airtable ticket associated with this PR.

N/A

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Ran the ETL locally, made sure that no logs around iso3 codes not being found were emitted.

## Does any infrastructure work need to be done before this PR can be pushed to production?

No.
