### PR TITLE
Sort countries in alpha order

### DIFF
--- a/app/database_etl/postgres_tables_handler/postgres_utils.py
+++ b/app/database_etl/postgres_tables_handler/postgres_utils.py
@@ -77,7 +77,8 @@ def get_all_filter_options():
         # Get countries
         query = session.query(distinct(getattr(Country, "country_name")))
         results = [q[0] for q in query if q[0] is not None]
-        options["country"] = results
+        # sort countries in alpha order
+        options["country"] = sorted(results)
 
         options["max_date"] = session.query(func.max(DashboardSource.sampling_end_date))[0][0].isoformat()
         options["min_date"] = session.query(func.min(DashboardSource.sampling_end_date))[0][0].isoformat()


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

Sort countries in alpha order when displaying them as filter options.

## Please link the Airtable ticket associated with this PR.

https://airtable.com/tbli2lWQHAqBa6ZcI/recp2r0QEdNRhW1wL

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Hit the /filter_options endpoint and verified.

## Does any infrastructure work need to be done before this PR can be pushed to production?

No.
