### PR TITLE
Meta analysis empty records fix

### DIFF
--- a/app/namespaces/meta_analysis/meta_analysis_controller.py
+++ b/app/namespaces/meta_analysis/meta_analysis_controller.py
@@ -64,6 +64,9 @@ class MetaAnalysis(Resource):
         columns = ['country', 'denominator_value', 'serum_pos_prevalence']
         columns.append(agg_var)
         records = get_filtered_records(filters=filters, columns=columns, start_date=start_date, end_date=end_date)
+        if not records:
+            logging.error('No records with specified filters found.')
+            return dict(records)
 
         meta_analysis_results = get_meta_analysis_records(records, agg_var, meta_transformation, meta_technique)
         return meta_analysis_results

--- a/app/namespaces/meta_analysis/meta_analysis_controller.py
+++ b/app/namespaces/meta_analysis/meta_analysis_controller.py
@@ -66,7 +66,7 @@ class MetaAnalysis(Resource):
         records = get_filtered_records(filters=filters, columns=columns, start_date=start_date, end_date=end_date)
         if not records:
             logging.error('No records with specified filters found.')
-            return dict(records)
+            return {}
 
         meta_analysis_results = get_meta_analysis_records(records, agg_var, meta_transformation, meta_technique)
         return meta_analysis_results


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- Meta analysis was throwing key errors when trying to aggregate records with the aggregation var if there were no records to aggregate
- No records occur if filters remove all records (e.g. source type = Publication is not a valid source type)

## Please link the Airtable ticket associated with this PR.

## Describe the steps you took to test the feature/bugfix introduced by this PR.
- Hit meta analysis endpoint using body in dev-logging-backend channel and see that empty dict is returned

## Does any infrastructure work need to be done before this PR can be pushed to production?
- No but I realized that when we copy the request body from the dev-logging-backend channel it is not in JSON format because there are single quotes instead of double, so you have to modify to change to JSON format before inputting in postman
- @abeljoseph can you modify the script so that if the request body is "m", instead of adding just "m" to the error you add m = json.dumps(m)?
