### PR TITLE
 Updated pagination endpoint

### DIFF
--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -5,7 +5,7 @@ from flask import jsonify, make_response, request
 
 from .data_provider_service import get_record_details, get_country_seroprev_summaries, jitter_pins
 from .data_provider_schema import RecordDetailsSchema, RecordsSchema, StudyCountSchema
-from app.utils import validate_request_input_against_schema, get_filtered_records, get_paginated_records_list, get_paginated_records_dict, convert_start_end_dates
+from app.utils import validate_request_input_against_schema, get_filtered_records, get_paginated_records, convert_start_end_dates
 from app.database_etl.postgres_tables_handler import get_all_filter_options
 
 data_provider_ns = Namespace('data_provider', description='Endpoints for getting database records.')
@@ -37,10 +37,6 @@ class Records(Resource):
             # If there was an error with the input payload, return the error and 422 response
             return make_response(payload, status_code)
 
-        sorting_key = data.get('sorting_key')
-        page_index = data.get('page_index')
-        per_page = data.get('per_page')
-        reverse = data.get('reverse')
         columns = data.get('columns')
         research_fields = data.get('research_fields')
         prioritize_estimates = data.get('prioritize_estimates', True)
@@ -50,10 +46,6 @@ class Records(Resource):
                                       prioritize_estimates=prioritize_estimates)
         if not columns or ("pin_latitude" in columns and "pin_longitude" in columns):
             result = jitter_pins(result)
-
-        # Only paginate if all the pagination parameters have been specified
-        if page_index is not None and per_page is not None and sorting_key is not None and reverse is not None:
-            result = get_paginated_records_list(result, sorting_key, page_index, per_page, reverse)
         return jsonify(result)
 
 @data_provider_ns.route('/records/paginated', methods=['POST'])
@@ -99,7 +91,7 @@ class Records(Resource):
 
         # Only paginate if all the pagination parameters have been specified
         if min_page_index is not None and max_page_index is not None and per_page is not None and sorting_key is not None and reverse is not None:
-            result = get_paginated_records_dict(result, sorting_key, min_page_index, max_page_index, per_page, reverse)
+            result = get_paginated_records(result, sorting_key, min_page_index, max_page_index, per_page, reverse)
         return jsonify(result)
 
 

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -13,35 +13,9 @@ data_provider_ns = Namespace('data_provider', description='Endpoints for getting
 logging.getLogger(__name__)
 
 
-@data_provider_ns.route('/records', methods=['GET', 'POST'])
+@data_provider_ns.route('/records', methods=['POST'])
 class Records(Resource):
     @data_provider_ns.doc('An endpoint for getting all records from database with or without filters.')
-    def get(self):
-        # Parse pagination request args if they are present
-        sorting_key = request.args.get('sorting_key', None, type=str)
-        min_page_index = request.args.get('min_page_index', None, type=int)
-        max_page_index = request.args.get('max_page_index', None, type=int)
-        per_page = request.args.get('per_page', None, type=int)
-
-        # Type must be string not bool, because bool evaluates to true for any non None value including False and True
-        research_fields = False if str.lower(request.args.get('research_fields', 'false', type=str)) == 'false' else True
-        prioritize_estimates = True if str.lower(request.args.get('prioritize_estimates', 'true', type=str)) == 'true' else False
-        reverse = False if str.lower(request.args.get('reverse', 'false', type=str)) == 'false' else True
-
-        # Log request info
-        logging.info("Endpoint Type: {type}, Endpoint Path: {path}, Arguments: {args}".format(
-            type=request.environ['REQUEST_METHOD'],
-            path=request.environ['PATH_INFO'],
-            args=dict(request.args)))
-
-        result = get_filtered_records(research_fields, filters=None, columns=None, start_date=None, end_date=None,
-                                      prioritize_estimates=prioritize_estimates)
-        result = jitter_pins(result)
-
-        # Only paginate if all the pagination parameters have been specified
-        if min_page_index is not None and max_page_index is not None and per_page is not None and sorting_key is not None and reverse is not None:
-            result = get_paginated_records(result, sorting_key, min_page_index, max_page_index, per_page, reverse)
-        return jsonify(result)
 
     def post(self):
         # Convert input payload to json and throw error if it doesn't exist

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -5,8 +5,7 @@ from flask import jsonify, make_response, request
 
 from .data_provider_service import get_record_details, get_country_seroprev_summaries, jitter_pins
 from .data_provider_schema import RecordDetailsSchema, RecordsSchema, StudyCountSchema
-from app.utils import validate_request_input_against_schema, get_filtered_records,\
-    get_paginated_records_list, get_paginated_records_dict convert_start_end_dates
+from app.utils import validate_request_input_against_schema, get_filtered_records, get_paginated_records_list, get_paginated_records_dict, convert_start_end_dates
 from app.database_etl.postgres_tables_handler import get_all_filter_options
 
 data_provider_ns = Namespace('data_provider', description='Endpoints for getting database records.')

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -74,11 +74,11 @@ class PaginatedRecords(Resource):
             # If there was an error with the input payload, return the error and 422 response
             return make_response(payload, status_code)
 
-        sorting_key = data.get('sorting_key')
+        sorting_key = data.get('sorting_key', None)
         min_page_index = data.get('min_page_index')
         max_page_index = data.get('max_page_index')
-        per_page = data.get('per_page')
-        reverse = data.get('reverse')
+        per_page = data.get('per_page', None)
+        reverse = data.get('reverse', None)
         columns = data.get('columns')
         research_fields = data.get('research_fields')
         prioritize_estimates = data.get('prioritize_estimates', True)
@@ -98,7 +98,7 @@ class PaginatedRecords(Resource):
             "sorting_key": sorting_key
         }
 
-        kwargs_not_none = { k: v for k, v in kwargs.items() if v is not None }
+        kwargs_not_none = { k:v for k, v in kwargs.items() if v is not None }
 
         # Only paginate if pagination params min_page_index, max_page_index and per_page are specified (sorting_key="sampling_end_date", reverse=true, per_page=5 by default)
         result = get_paginated_records(**kwargs_not_none)

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -19,13 +19,14 @@ class Records(Resource):
     def get(self):
         # Parse pagination request args if they are present
         sorting_key = request.args.get('sorting_key', None, type=str)
-        reverse = request.args.get('reverse', None, type=bool)
-        page_index = request.args.get('page_index', None, type=int)
+        min_page_index = request.args.get('min_page_index', None, type=int)
+        max_page_index = request.args.get('max_page_index', None, type=int)
         per_page = request.args.get('per_page', None, type=int)
 
         # Type must be string not bool, because bool evaluates to true for any non None value including False and True
         research_fields = False if str.lower(request.args.get('research_fields', 'false', type=str)) == 'false' else True
         prioritize_estimates = True if str.lower(request.args.get('prioritize_estimates', 'true', type=str)) == 'true' else False
+        reverse = False if str.lower(request.args.get('reverse', 'false', type=str)) == 'false' else True
 
         # Log request info
         logging.info("Endpoint Type: {type}, Endpoint Path: {path}, Arguments: {args}".format(
@@ -38,8 +39,8 @@ class Records(Resource):
         result = jitter_pins(result)
 
         # Only paginate if all the pagination parameters have been specified
-        if page_index is not None and per_page is not None and sorting_key is not None and reverse is not None:
-            result = get_paginated_records(result, sorting_key, page_index, per_page, reverse)
+        if min_page_index is not None and max_page_index is not None and per_page is not None and sorting_key is not None and reverse is not None:
+            result = get_paginated_records(result, sorting_key, min_page_index, max_page_index, per_page, reverse)
         return jsonify(result)
 
     def post(self):
@@ -65,7 +66,8 @@ class Records(Resource):
             return make_response(payload, status_code)
 
         sorting_key = data.get('sorting_key')
-        page_index = data.get('page_index')
+        min_page_index = data.get('min_page_index')
+        max_page_index = data.get('max_page_index')
         per_page = data.get('per_page')
         reverse = data.get('reverse')
         columns = data.get('columns')
@@ -79,8 +81,8 @@ class Records(Resource):
             result = jitter_pins(result)
 
         # Only paginate if all the pagination parameters have been specified
-        if page_index is not None and per_page is not None and sorting_key is not None and reverse is not None:
-            result = get_paginated_records(result, sorting_key, page_index, per_page, reverse)
+        if min_page_index is not None and max_page_index is not None and per_page is not None and sorting_key is not None and reverse is not None:
+            result = get_paginated_records(result, sorting_key, min_page_index, max_page_index, per_page, reverse)
         return jsonify(result)
 
 

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -5,7 +5,6 @@ class RecordsSchema(Schema):
     sorting_key = fields.String(validate=validate.OneOf(["serum_pos_prevalence", "denominator_value",
                                                          "overall_risk_of_bias", "source_name",
                                                          "source_id", "sampling_end_date"]))
-    page_index = fields.Integer(allow_none=True)
     min_page_index = fields.Integer(allow_none=True)
     max_page_index = fields.Integer(allow_none=True)
     per_page = fields.Integer(allow_none=True)

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -4,8 +4,9 @@ from marshmallow import Schema, fields, validate
 class RecordsSchema(Schema):
     sorting_key = fields.String(validate=validate.OneOf(["serum_pos_prevalence", "denominator_value",
                                                          "overall_risk_of_bias", "source_name",
-                                                         "source_id"]))
-    page_index = fields.Integer(allow_none=True)
+                                                         "source_id", "sampling_end_date"]))
+    min_page_index = fields.Integer(allow_none=True)
+    max_page_index = fields.Integer(allow_none=True)
     per_page = fields.Integer(allow_none=True)
     reverse = fields.Boolean(allow_none=True)
     research_fields = fields.Boolean(allow_none=True)

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -5,8 +5,8 @@ class RecordsSchema(Schema):
     sorting_key = fields.String(validate=validate.OneOf(["serum_pos_prevalence", "denominator_value",
                                                          "overall_risk_of_bias", "source_name",
                                                          "source_id", "sampling_end_date"]))
-    min_page_index = fields.Integer(allow_none=True)
-    max_page_index = fields.Integer(allow_none=True)
+    # TODO: Deprecreate page_index, sorting_key, per_page, reverse from RecordsSchema once we update the frontend to not make requests to /records
+    page_index = fields.Integer(allow_none=True)
     per_page = fields.Integer(allow_none=True)
     reverse = fields.Boolean(allow_none=True)
     research_fields = fields.Boolean(allow_none=True)
@@ -35,6 +35,14 @@ class RecordsSchema(Schema):
     start_date = fields.String()
     end_date = fields.String()
 
+class PaginatedRecordsSchema(RecordsSchema):
+    sorting_key = fields.String(validate=validate.OneOf(["serum_pos_prevalence", "denominator_value",
+                                                         "overall_risk_of_bias", "source_name",
+                                                         "source_id", "sampling_end_date"]), allow_none=True)
+    min_page_index = fields.Integer()
+    max_page_index = fields.Integer()
+    per_page = fields.Integer(allow_none=True)
+    reverse = fields.Boolean(allow_none=True)
 
 class RecordDetailsSchema(Schema):
     source_id = fields.UUID(required=True)

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -5,6 +5,7 @@ class RecordsSchema(Schema):
     sorting_key = fields.String(validate=validate.OneOf(["serum_pos_prevalence", "denominator_value",
                                                          "overall_risk_of_bias", "source_name",
                                                          "source_id", "sampling_end_date"]))
+    page_index = fields.Integer(allow_none=True)
     min_page_index = fields.Integer(allow_none=True)
     max_page_index = fields.Integer(allow_none=True)
     per_page = fields.Integer(allow_none=True)

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -39,8 +39,8 @@ class PaginatedRecordsSchema(RecordsSchema):
     sorting_key = fields.String(validate=validate.OneOf(["serum_pos_prevalence", "denominator_value",
                                                          "overall_risk_of_bias", "source_name",
                                                          "source_id", "sampling_end_date"]), allow_none=True)
-    min_page_index = fields.Integer()
-    max_page_index = fields.Integer()
+    min_page_index = fields.Integer(required=True)
+    max_page_index = fields.Integer(required=True)
     per_page = fields.Integer(allow_none=True)
     reverse = fields.Boolean(allow_none=True)
 

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -3,5 +3,5 @@ from .notifications_sender import send_api_error_slack_notif, send_slack_message
 from .cached_json_handler import write_to_json, read_from_json
 from .helper_funcs import validate_request_input_against_schema, convert_start_end_dates
 from .airtable_fields_config import airtable_fields_config, full_airtable_fields
-from .get_filtered_records import get_filtered_records, get_paginated_records
+from .get_filtered_records import get_filtered_records, get_paginated_records_list, get_paginated_records_dict
 from .estimate_prioritization import get_prioritized_estimates

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -3,5 +3,5 @@ from .notifications_sender import send_api_error_slack_notif, send_slack_message
 from .cached_json_handler import write_to_json, read_from_json
 from .helper_funcs import validate_request_input_against_schema, convert_start_end_dates
 from .airtable_fields_config import airtable_fields_config, full_airtable_fields
-from .get_filtered_records import get_filtered_records, get_paginated_records_list, get_paginated_records_dict
+from .get_filtered_records import get_filtered_records, get_paginated_records
 from .estimate_prioritization import get_prioritized_estimates

--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -227,18 +227,7 @@ def get_filtered_records(research_fields=False, filters=None, columns=None, star
 '''
 Note: `page_index` is zero-indexed here!
 '''
-
-def get_paginated_records_list(query_dicts, sorting_key, page_index, per_page, reverse):
-    # Order the records first
-    sorted_records = sorted(query_dicts, key=lambda x: (x[sorting_key] is None, x[sorting_key]), reverse=reverse)
-
-    start = page_index * per_page
-    end = page_index * per_page + per_page
-
-    return sorted_records[start:end]
-
-
-def get_paginated_records_dict(query_dicts, sorting_key, min_page_index, max_page_index, per_page, reverse):
+def get_paginated_records(query_dicts, sorting_key, min_page_index, max_page_index, per_page, reverse):
     # Order the records first
     sorted_records = sorted(query_dicts, key=lambda x: (x[sorting_key] is None, x[sorting_key]), reverse=reverse)
 

--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -6,6 +6,7 @@ import pandas as pd
 import numpy as np
 from .estimate_prioritization import get_prioritized_estimates
 from statistics import mean
+from typing import List, Dict, Any
 
 
 def get_all_records(research_fields=False):
@@ -224,12 +225,19 @@ def get_filtered_records(research_fields=False, filters=None, columns=None, star
         result = [grab_cols(i, columns) for i in result]
     return result
 
+'''Gets and returns a dictionary of pages of records
+
+:param records: list of unpaginated records
+:param min_page_index: minimum page index
+:param max_page_index: maximum page index
+:param per_page: number of records per page
+:param reverse: whether to sort list of unpaginated records in reverse order or not 
+:param sorting_key: key by which list of unpaginated records are sorted
+:returns a dictionary of lists of records (len(list) == per_page)
 '''
-Note: `page_index` is zero-indexed here!
-'''
-def get_paginated_records(query_dicts, sorting_key, min_page_index, max_page_index, per_page, reverse):
+def get_paginated_records(records: List[Dict[str, Any]], min_page_index: int, max_page_index: int, per_page: int = 5, reverse: bool = False, sorting_key: str = "sampling_end_date") -> Dict[int, List[Dict[str, Any]]]:
     # Order the records first
-    sorted_records = sorted(query_dicts, key=lambda x: (x[sorting_key] is None, x[sorting_key]), reverse=reverse)
+    sorted_records = sorted(records, key=lambda x: (x[sorting_key] is None, x[sorting_key]), reverse=reverse)
 
     # Input is non-zero indexing, but we map to zero indexing (e.g. input 1-3 maps to 0-2) but we still return non-zero indexing
     min_page_index -= 1

--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -229,11 +229,13 @@ Note: `page_index` is zero-indexed here!
 '''
 
 
-def get_paginated_records(query_dicts, sorting_key, page_index, per_page, reverse):
+def get_paginated_records(query_dicts, sorting_key, min_page_index, max_page_index, per_page, reverse):
     # Order the records first
     sorted_records = sorted(query_dicts, key=lambda x: (x[sorting_key] is None, x[sorting_key]), reverse=reverse)
 
-    start = page_index * per_page
-    end = page_index * per_page + per_page
+    # Input is non-zero indexing, but we map to zero indexing (e.g. input 1-3 maps to 0-2) but we still return non-zero indexing
+    min_page_index -= 1
+    max_page_index -= 1
 
-    return sorted_records[start:end]
+    # Create dictionary of pages of records 
+    return {i+1:sorted_records[i*per_page:i*per_page+per_page] if i * per_page + per_page < len(sorted_records) else sorted_records[i*per_page:] for i in range(min_page_index, max_page_index + 1)} 

--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -228,8 +228,17 @@ def get_filtered_records(research_fields=False, filters=None, columns=None, star
 Note: `page_index` is zero-indexed here!
 '''
 
+def get_paginated_records_list(query_dicts, sorting_key, page_index, per_page, reverse):
+    # Order the records first
+    sorted_records = sorted(query_dicts, key=lambda x: (x[sorting_key] is None, x[sorting_key]), reverse=reverse)
 
-def get_paginated_records(query_dicts, sorting_key, min_page_index, max_page_index, per_page, reverse):
+    start = page_index * per_page
+    end = page_index * per_page + per_page
+
+    return sorted_records[start:end]
+
+
+def get_paginated_records_dict(query_dicts, sorting_key, min_page_index, max_page_index, per_page, reverse):
     # Order the records first
     sorted_records = sorted(query_dicts, key=lambda x: (x[sorting_key] is None, x[sorting_key]), reverse=reverse)
 
@@ -238,4 +247,7 @@ def get_paginated_records(query_dicts, sorting_key, min_page_index, max_page_ind
     max_page_index -= 1
 
     # Create dictionary of pages of records 
-    return {i+1:sorted_records[i*per_page:i*per_page+per_page] if i * per_page + per_page < len(sorted_records) else sorted_records[i*per_page:] for i in range(min_page_index, max_page_index + 1)} 
+    return {i+1:sorted_records[i*per_page:i*per_page+per_page] 
+            if i * per_page + per_page < len(sorted_records) 
+            else sorted_records[i*per_page:] 
+            for i in range(min_page_index, max_page_index + 1)} 


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
Modified `get_pagination_records` to return a dictionary of lists of records (between a start and end page index). Previously, it returned a single page of records. 

## Please link the Airtable ticket associated with this PR.
[Ticket link](https://airtable.com/tbli2lWQHAqBa6ZcI/viw8Ro4zYPYcBGXRw/receg2IU5tYhWuQzM?blocks=hide)

## Describe the steps you took to test the feature/bugfix introduced by this PR.
Made GET and POST requests with the pagination parameters and ensured the behaviour was correct

## Does any infrastructure work need to be done before this PR can be pushed to production?
Nope!
