### PR TITLE
fix first_author index out of bounds error

### DIFF
--- a/app/database_etl/airtable_records_handler/airtable_records_formatter.py
+++ b/app/database_etl/airtable_records_handler/airtable_records_formatter.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from ..location_utils import get_city
 
+
 def get_most_recent_publication_info(row):
     # Get index of most recent pub date if the pub date is not None
     try:
@@ -12,16 +13,25 @@ def get_most_recent_publication_info(row):
     # If pub date is None set to index to 0
     except AttributeError:
         max_index = 0
-
     # If source type exists, get element at that index
     if row['source_type']:
-        row['source_type'] = row['source_type'][max_index]
+        # We should take either the max_index based on the latest pub date,
+        # or the last element of source type if the max index doesn't exist
+        i = min(max_index, len(row['source_type']) - 1)
+        row['source_type'] = row['source_type'][i]
 
     # Index whether org author exists and corresponding first author
     if row['organizational_author'] and row['first_author']:
-        is_org_author = row['organizational_author'][max_index]
+        # We should take either the max_index based on the latest pub date,
+        # or the last element of org author if the max index doesn't exist
+        i = min(max_index, len(row['organizational_author']) - 1)
+        is_org_author = row['organizational_author'][i]
         row['organizational_author'] = is_org_author
-        row['first_author'] = row['first_author'][max_index]
+
+        # We should take either the max_index based on the latest pub date,
+        # or the last element of first author if the max index doesn't exist
+        i = min(max_index, len(row['first_author']) - 1)
+        row['first_author'] = row['first_author'][i]
 
         # If it is not an organizational author, then get last name
         if not is_org_author and len(row['first_author']) > 0:

--- a/app/database_etl/airtable_records_handler/airtable_records_formatter.py
+++ b/app/database_etl/airtable_records_handler/airtable_records_formatter.py
@@ -1,9 +1,11 @@
 import numpy as np
 
+from typing import Dict
+
 from ..location_utils import get_city
 
 
-def get_most_recent_publication_info(row):
+def get_most_recent_publication_info(row: Dict) -> Dict:
     # Get index of most recent pub date if the pub date is not None
     try:
         pub_dates = row['publication_date']


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- in the ETL, we were getting an issue where if there were multiple first authors listed, the index that was computed was longer than the number of first authors, so it threw an index out of bounds error
- this is because for first_author, organizational_author, and source_type, there can be multiple of these three, and we should take the one corresponding to the max publication date
- in some cases, there may not be a first_author corresponding to the max pub date
- example: publication_dates: [2020-03-10, 2020-05,11]. The max pub date corresponds to index 1, so we should get the element of first_author, organizational_author, and source_type where index = 1. If first_author: [person], then first_author[1], is out of bounds. In this case, if the index is out of bounds, get the value with the largest index instead (in this case 0)
- apply this logic to organizational_author and source_type too

## Please link the Airtable ticket associated with this PR.
- N/A

## Describe the steps you took to test the feature/bugfix introduced by this PR.
- ran ETL, made sure no out of bounds error occurred

## Does any infrastructure work need to be done before this PR can be pushed to production?
