### PR TITLE
Fix drop tables

### DIFF
--- a/app/database_etl/postgres_tables_handler/postgres_loader.py
+++ b/app/database_etl/postgres_tables_handler/postgres_loader.py
@@ -4,6 +4,7 @@ import pandas as pd
 from marshmallow import ValidationError, INCLUDE
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import or_
+import datetime
 
 from app.utils.notifications_sender import send_schema_validation_slack_notif, send_slack_message
 from app.serotracker_sqlalchemy import db_session, DashboardSource, ResearchSource, Country, City, State, \
@@ -68,7 +69,7 @@ def load_postgres_tables(tables_dict, engine):
     return True
 
 
-def drop_table_entries(current_time, drop_old=True):
+def drop_table_entries(current_time: datetime, drop_old: bool = True):
     for table_name in table_names_dict:
         table = table_names_dict[table_name]
         with db_session() as session:

--- a/app/database_etl/postgres_tables_handler/postgres_loader.py
+++ b/app/database_etl/postgres_tables_handler/postgres_loader.py
@@ -3,6 +3,7 @@ import logging
 import pandas as pd
 from marshmallow import ValidationError, INCLUDE
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy import or_
 
 from app.utils.notifications_sender import send_schema_validation_slack_notif, send_slack_message
 from app.serotracker_sqlalchemy import db_session, DashboardSource, ResearchSource, Country, City, State, \
@@ -73,9 +74,9 @@ def drop_table_entries(current_time, drop_old=True):
         with db_session() as session:
             if drop_old:
                 # Drop old records if type is old
-                session.query(table).filter(table.created_at != current_time).delete()
+                session.query(table).filter(or_(table.created_at != current_time, table.created_at.is_(None))).delete()
             else:
                 # Drop new records if type is new
-                session.query(table).filter(table.created_at == current_time).delete()
+                session.query(table).filter(or_(table.created_at == current_time, table.created_at.is_(None))).delete()
             session.commit()
     return


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

`drop_table_entries` needs to explicitly look for entries with `created_at` = null when determining which entries to drop. 

Somehow on our production database, we inserted many records into `research_source` without a `created_at` field, they have not been deleted to this day. This PR should fix that.

## Please link the Airtable ticket associated with this PR.

N/A

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Manually ran ETL locally, made sure that entries with null `created_at` values in all tables were deleted.

## Does any infrastructure work need to be done before this PR can be pushed to production?

N/A
