### PR TITLE
Filter option changes

### DIFF
--- a/app/database_etl/postgres_tables_handler/postgres_utils.py
+++ b/app/database_etl/postgres_tables_handler/postgres_utils.py
@@ -47,6 +47,9 @@ def get_filter_static_options() -> Dict[str, List[str]]:
             "Health care workers and caregivers",
             "Family of essential workers"
         ],
+        "prioritize_estimates_mode": [
+            "analysis_dynamic",
+            "analysis_static"],
         "sex": [
             "Female",
             "Male",

--- a/app/database_etl/postgres_tables_handler/postgres_utils.py
+++ b/app/database_etl/postgres_tables_handler/postgres_utils.py
@@ -84,8 +84,10 @@ def get_all_filter_options() -> Dict[str, Any]:
         # sort countries in alpha order
         options["country"] = sorted(results)
 
-        options["max_date"] = session.query(func.max(DashboardSource.sampling_end_date))[0][0].isoformat()
-        options["min_date"] = session.query(func.min(DashboardSource.sampling_end_date))[0][0].isoformat()
+        options["max_sampling_end_date"] = session.query(func.max(DashboardSource.sampling_end_date))[0][0].isoformat()
+        options["min_sampling_end_date"] = session.query(func.min(DashboardSource.sampling_end_date))[0][0].isoformat()
+        options["max_publication_end_date"] = session.query(func.max(DashboardSource.publication_date))[0][0].isoformat()
+        options["min_publication_end_date"] = session.query(func.min(DashboardSource.publication_date))[0][0].isoformat()
         options["updated_at"] = session.query(func.max(DashboardSource.publication_date))[0][0].isoformat()
 
         return options

--- a/app/database_etl/postgres_tables_handler/postgres_utils.py
+++ b/app/database_etl/postgres_tables_handler/postgres_utils.py
@@ -49,7 +49,8 @@ def get_filter_static_options() -> Dict[str, List[str]]:
         ],
         "prioritize_estimates_mode": [
             "analysis_dynamic",
-            "analysis_static"],
+            "analysis_static",
+            "dashboard"],
         "sex": [
             "Female",
             "Male",

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -40,6 +40,8 @@ class Records(Resource):
         columns = data.get('columns')
         research_fields = data.get('research_fields')
         prioritize_estimates = data.get('prioritize_estimates', True)
+        prioritize_estimates_mode = data.get('prioritize_estimates_mode', None)
+
         sampling_start_date, sampling_end_date = convert_start_end_dates(data, use_sampling_date=True)
         publication_start_date, publication_end_date = convert_start_end_dates(data, use_sampling_date=False)
 
@@ -50,7 +52,8 @@ class Records(Resource):
                                       sampling_end_date=sampling_end_date,
                                       publication_start_date=publication_start_date,
                                       publication_end_date=publication_end_date,
-                                      prioritize_estimates=prioritize_estimates)
+                                      prioritize_estimates=prioritize_estimates,
+                                      prioritize_estimates_mode=prioritize_estimates_mode)
         if not columns or ("pin_latitude" in columns and "pin_longitude" in columns):
             result = jitter_pins(result)
         return jsonify(result)
@@ -89,11 +92,13 @@ class PaginatedRecords(Resource):
         columns = data.get('columns')
         research_fields = data.get('research_fields')
         prioritize_estimates = data.get('prioritize_estimates', True)
+        prioritize_estimates_mode = data.get('prioritize_estimates_mode', None)
         sampling_start_date, sampling_end_date = convert_start_end_dates(data, use_sampling_date=True)
 
         result = get_filtered_records(research_fields, filters, columns, sampling_start_date=sampling_start_date,
                                       sampling_end_date=sampling_end_date,
-                                      prioritize_estimates=prioritize_estimates)
+                                      prioritize_estimates=prioritize_estimates,
+                                      prioritize_estimates_mode=prioritize_estimates_mode)
         if not columns or ("pin_latitude" in columns and "pin_longitude" in columns):
             result = jitter_pins(result)
 

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -11,8 +11,9 @@ class RecordsSchema(Schema):
     reverse = fields.Boolean(allow_none=True)
     research_fields = fields.Boolean(allow_none=True)
     prioritize_estimates = fields.Boolean(allow_none=True)
-    prioritize_estimates_mode = fields.String(validate=validate.OneOf(['analysis_dynamic', 'analysis_static']),
-                                              allow_none=True)
+    prioritize_estimates_mode = fields.String(validate=validate.OneOf(['analysis_dynamic',
+                                                                       'analysis_static',
+                                                                       'dashboard']), allow_none=True)
     filters = fields.Dict(
         keys=fields.String(validate=validate.OneOf(["country", "source_type", "overall_risk_of_bias",
                                                     "source_name", "population_group",

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -5,12 +5,14 @@ class RecordsSchema(Schema):
     sorting_key = fields.String(validate=validate.OneOf(["serum_pos_prevalence", "denominator_value",
                                                          "overall_risk_of_bias", "source_name",
                                                          "source_id", "sampling_end_date"]))
-    # TODO: Deprecreate page_index, sorting_key, per_page, reverse from RecordsSchema once we update the frontend to not make requests to /records
+    # TODO: Deprecate page_index, sorting_key, per_page, reverse from RecordsSchema once we update the frontend to not make requests to /records
     page_index = fields.Integer(allow_none=True)
     per_page = fields.Integer(allow_none=True)
     reverse = fields.Boolean(allow_none=True)
     research_fields = fields.Boolean(allow_none=True)
     prioritize_estimates = fields.Boolean(allow_none=True)
+    prioritize_estimates_mode = fields.String(validate=validate.OneOf(['analysis_dynamic', 'analysis_static']),
+                                              allow_none=True)
     filters = fields.Dict(
         keys=fields.String(validate=validate.OneOf(["country", "source_type", "overall_risk_of_bias",
                                                     "source_name", "population_group",

--- a/app/utils/estimate_prioritization.py
+++ b/app/utils/estimate_prioritization.py
@@ -100,10 +100,7 @@ def get_pooled_estimate(estimates):
         return pooled  
 
 
-def get_prioritized_estimates(estimates, 
-                              filters = None, 
-                              mode = 'analysis_dynamic'): 
-    
+def get_prioritized_estimates(estimates, filters=None, mode=None):
     if filters is not None:
         estimates = estimates[filters]
     if estimates.shape[0] == 0:

--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -127,7 +127,8 @@ Output: set of records represented by dicts
 
 def get_filtered_records(research_fields=False, filters=None, columns=None,
                          sampling_start_date=None, sampling_end_date=None,
-                         publication_start_date=None, publication_end_date=None, prioritize_estimates=True):
+                         publication_start_date=None, publication_end_date=None, prioritize_estimates=True,
+                         prioritize_estimates_mode=None):
     query_dicts = get_all_records(research_fields)
     if query_dicts is None or len(query_dicts) == 0:
         return []
@@ -188,7 +189,7 @@ def get_filtered_records(research_fields=False, filters=None, columns=None,
     # or keep everything in dataframes (don't want to have this conversion here long term)
     if prioritize_estimates:
         result_df = pd.DataFrame(result)
-        prioritized_records = get_prioritized_estimates(result_df, mode="dashboard")
+        prioritized_records = get_prioritized_estimates(result_df, mode=prioritize_estimates_mode)
         if not prioritized_records.empty:
             # Filling all NaN values with None: https://stackoverflow.com/questions/46283312/how-to-proceed-with-none-value-in-pandas-fillna
             prioritized_records = prioritized_records.fillna(np.nan).replace({np.nan: None})


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
1. Add bounds for publication date to /filter_options endpoint
2. Add option to pass in 'mode' for estimate_prioritization. Don't have to pass anything in, in which case mode defaults to None, otherwise can pass in analysis_dynamic or analysis_static

## Please link the Airtable ticket associated with this PR.
https://airtable.com/tbli2lWQHAqBa6ZcI/viw8Ro4zYPYcBGXRw/reco3hpy0xYMEdZqw

## Describe the steps you took to test the feature/bugfix introduced by this PR.
- tested the /filter_options endpoint, and made sure was getting right values for bounds on pub date and sampling end date
- tested estimate prioritization with no mode, with correct modes, and incorrect modes (to test the schema check)

## Does any infrastructure work need to be done before this PR can be pushed to production?
NO
