### PR TITLE
Pull additional fields through to dashboard

### DIFF
--- a/app/serotracker_sqlalchemy/db_model_config.py
+++ b/app/serotracker_sqlalchemy/db_model_config.py
@@ -41,7 +41,9 @@ dashboard_source_cols = ['source_name', 'source_type', 'study_name', 'denominato
                          'isotype_comb', 'academic_primary_estimate', 'dashboard_primary_estimate', 'pop_adj',
                          'test_adj', 'specimen_type', 'test_type', 'population_group', 'url', 'cases_per_hundred',
                          'tests_per_hundred', 'deaths_per_hundred', 'vaccinations_per_hundred',
-                         'full_vaccinations_per_hundred', 'publication_date', 'geo_exact_match']
+                         'full_vaccinations_per_hundred', 'publication_date', 'geo_exact_match',
+                         'sensitivity', 'specificity', 'summary', 'study_type', 'source_publisher', 'lead_organization',
+                         'first_author']
 
 research_source_cols = ['case_population', 'deaths_population', 'age_max', 'age_min', 'age_variation',
                         'age_variation_measure', 'average_age', 'case_count_neg14', 'case_count_neg9',


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- send these fields to dashboard: 'sensitivity', 'specificity', 'summary', 'study_type', 'source_publisher', 'lead_organization',
                         'first_author'

## Please link the Airtable ticket associated with this PR.
https://airtable.com/tbli2lWQHAqBa6ZcI/viw8Ro4zYPYcBGXRw/recX5I9zu7Rz0ZnXb 

## Describe the steps you took to test the feature/bugfix introduced by this PR.
- tested dashboard get records endpoint to make sure these are pulled through by default

## Does any infrastructure work need to be done before this PR can be pushed to production?
- no
