### PR TITLE
Add 'ETL Included' filter to airtable API request

### DIFF
--- a/app/database_etl/airtable_records_handler/airtable_records_formatter.py
+++ b/app/database_etl/airtable_records_handler/airtable_records_formatter.py
@@ -62,10 +62,6 @@ def standardize_airtable_data(df):
     # Replace columns that should be floats with NaN from None and rescale to percentage
     df[['ind_sp', 'ind_se']] = df[['ind_sp', 'ind_se']].replace({None: np.nan}) / 100
 
-    # Drop rows if columns are null: included?, serum pos prevalence, denominator, sampling end
-    df.dropna(subset=['included', 'serum_pos_prevalence', 'denominator_value', 'sampling_end_date'],
-              inplace=True)
-
     # Convert superceded to True/False values
     df['superceded'] = df['superceded'].apply(lambda x: True if x else False)
 

--- a/app/database_etl/airtable_records_handler/airtable_records_getter.py
+++ b/app/database_etl/airtable_records_handler/airtable_records_getter.py
@@ -55,6 +55,7 @@ def get_all_records():
     # Get airtable API URL and add fields to be scraped to URL in HTML format
     url = AIRTABLE_REQUEST_URL.format(AIRTABLE_BASE_ID)
     url = _add_fields_to_url(url)
+    url += '&filterByFormula={ETL Included}=1'
     headers = {'Authorization': 'Bearer {}'.format(AIRTABLE_API_KEY)}
 
     # Make request and retrieve records in json format


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- Added a new column to airtable called 'ETL Included' that is 1 if Included, Serum pos prevalence, Denominator and Sampling End Date are all not blank, and 0 if any of them are blank
- Added a 'filterByFormula' term to the airtable API request to only pull fields where ETL Included = 1
- Removing code to drop rows where either of these 4 fields is null in the ETL

## Please link the Airtable ticket associated with this PR.
https://airtable.com/tbli2lWQHAqBa6ZcI/viwp6zUTCqlERLzMj/recMca3RyfhpOQYYO?blocks=hide 

## Describe the steps you took to test the feature/bugfix introduced by this PR.
- Checked to make sure that the number of records pulled from airtable when ETL Included = 1 is the same as the number of records without this filter after dropping null fields in ETL

## Does any infrastructure work need to be done before this PR can be pushed to production?
- NO
