### PR TITLE
Add subgroup filter options

### DIFF
--- a/app/database_etl/postgres_tables_handler/postgres_utils.py
+++ b/app/database_etl/postgres_tables_handler/postgres_utils.py
@@ -78,7 +78,7 @@ def get_filter_static_options() -> Dict[str, List[str]]:
         "genpop": [
             'Study examining general population seroprevalence',
             'Study examining special population seroprevalence',
-        ]
+        ],
         "subgroup_var": [
            'Geographical area', 'Health care worker exposure', 'Population',
            'Primary Estimate', 'Comorbidities', 'Sex/Gender',

--- a/app/database_etl/postgres_tables_handler/postgres_utils.py
+++ b/app/database_etl/postgres_tables_handler/postgres_utils.py
@@ -75,6 +75,10 @@ def get_filter_static_options() -> Dict[str, List[str]]:
             "LFIA",
             "Other"
         ],
+        "genpop": [
+            'Study examining general population seroprevalence',
+            'Study examining special population seroprevalence',
+        ]
         "subgroup_var": [
            'Geographical area', 'Health care worker exposure', 'Population',
            'Primary Estimate', 'Comorbidities', 'Sex/Gender',

--- a/app/database_etl/postgres_tables_handler/postgres_utils.py
+++ b/app/database_etl/postgres_tables_handler/postgres_utils.py
@@ -74,7 +74,25 @@ def get_filter_static_options() -> Dict[str, List[str]]:
             "ELISA",
             "LFIA",
             "Other"
-        ]
+        ],
+        "subgroup_var": [
+           'Geographical area', 'Health care worker exposure', 'Population',
+           'Primary Estimate', 'Comorbidities', 'Sex/Gender',
+           'Type of health care worker', 'Age', 'Exposure level',
+           'Occupation', 'Time frame', 'Race', 'Health care setting',
+           'Analysis', 'Patient group', 'Employment status', 'BMI',
+           'Test Used', 'Blood type', 'Medications',
+           'Exposure level granular', 'Isotype', 'Asymptomatic',
+           'Antibody target', 'Alcohol Intake', 'Household size', 'Symptoms',
+           'Non-COVID therapy', 'Dwelling', 'Education', 'Ethnicity',
+           'Nationality', 'Income', 'Smoking status', 'Travel',
+           'Population size/density ', 'Institution', 'SES',
+           'Serostatus timing', 'Vaccination Status', 'Recruitment method'
+        ],
+        "subgroup_cat": {
+            'Various options depending on subgroup var',
+            'See Airtable or data dictionary for full list'
+        }
     }
 
 

--- a/app/database_etl/postgres_tables_handler/postgres_utils.py
+++ b/app/database_etl/postgres_tables_handler/postgres_utils.py
@@ -29,8 +29,8 @@ def get_filter_static_options() -> Dict[str, List[str]]:
             "Unclear"
         ],
         "population_group": [
-            "Blood donors",
             "Household and community samples",
+            "Blood donors",
             "Residual sera",
             "Assisted living and long-term care facilities",
             "Students and Daycares",
@@ -75,28 +75,6 @@ def get_filter_static_options() -> Dict[str, List[str]]:
             "LFIA",
             "Other"
         ],
-        "genpop": [
-            'Study examining general population seroprevalence',
-            'Study examining special population seroprevalence',
-        ],
-        "subgroup_var": [
-           'Geographical area', 'Health care worker exposure', 'Population',
-           'Primary Estimate', 'Comorbidities', 'Sex/Gender',
-           'Type of health care worker', 'Age', 'Exposure level',
-           'Occupation', 'Time frame', 'Race', 'Health care setting',
-           'Analysis', 'Patient group', 'Employment status', 'BMI',
-           'Test Used', 'Blood type', 'Medications',
-           'Exposure level granular', 'Isotype', 'Asymptomatic',
-           'Antibody target', 'Alcohol Intake', 'Household size', 'Symptoms',
-           'Non-COVID therapy', 'Dwelling', 'Education', 'Ethnicity',
-           'Nationality', 'Income', 'Smoking status', 'Travel',
-           'Population size/density ', 'Institution', 'SES',
-           'Serostatus timing', 'Vaccination Status', 'Recruitment method'
-        ],
-        "subgroup_cat": {
-            'Various options depending on subgroup var',
-            'See Airtable or data dictionary for full list'
-        }
     }
 
 
@@ -109,6 +87,21 @@ def get_all_filter_options() -> Dict[str, Any]:
         results = [q[0] for q in query if q[0] is not None]
         # sort countries in alpha order
         options["country"] = sorted(results)
+        
+        # Get genpop
+        query = session.query(distinct(ResearchSource.genpop))
+        results = [q[0] for q in query if q[0] is not None]
+        options["genpop"] = sorted(results)
+        
+        # Get subgroup_var
+        query = session.query(distinct(ResearchSource.subgroup_var))
+        results = [q[0] for q in query if q[0] is not None]
+        options["subgroup_var"] = sorted(results)
+        
+        # Get subgroup_cat
+        query = session.query(distinct(ResearchSource.subgroup_cat))
+        results = [q[0] for q in query if q[0] is not None]
+        options["subgroup_cat"] = sorted(results)
 
         options["max_sampling_end_date"] = session.query(func.max(DashboardSource.sampling_end_date))[0][0].isoformat()
         options["min_sampling_end_date"] = session.query(func.min(DashboardSource.sampling_end_date))[0][0].isoformat()

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -18,7 +18,8 @@ class RecordsSchema(Schema):
         keys=fields.String(validate=validate.OneOf(["country", "source_type", "overall_risk_of_bias",
                                                     "source_name", "population_group",
                                                     "sex", "age", "isotypes_reported", "test_type",
-                                                    "specimen_type", "estimate_grade"])),
+                                                    "specimen_type", "estimate_grade",
+                                                    "subgroup_var", "subgroup_cat"])),
         values=fields.List(fields.String())
     )
     columns = fields.List(fields.String(validate=validate.OneOf(["age", "city", "state", "population_group",
@@ -62,7 +63,8 @@ class StudyCountSchema(Schema):
         keys=fields.String(validate=validate.OneOf(["country", "source_type", "overall_risk_of_bias",
                                                     "source_name", "population_group",
                                                     "sex", "age", "isotypes_reported", "test_type",
-                                                    "specimen_type", "estimate_grade"])),
+                                                    "specimen_type", "estimate_grade",
+                                                    "subgroup_var", "subgroup_cat"])),
         values=fields.List(fields.String())
     )
     sampling_start_date = fields.String()

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -16,7 +16,7 @@ class RecordsSchema(Schema):
                                                                        'dashboard']), allow_none=True)
     filters = fields.Dict(
         keys=fields.String(validate=validate.OneOf(["country", "source_type", "overall_risk_of_bias",
-                                                    "source_name", "population_group",
+                                                    "source_name", "population_group", "genpop",
                                                     "sex", "age", "isotypes_reported", "test_type",
                                                     "specimen_type", "estimate_grade",
                                                     "subgroup_var", "subgroup_cat"])),

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -61,7 +61,7 @@ class RecordDetailsSchema(Schema):
 class StudyCountSchema(Schema):
     filters = fields.Dict(
         keys=fields.String(validate=validate.OneOf(["country", "source_type", "overall_risk_of_bias",
-                                                    "source_name", "population_group",
+                                                    "source_name", "population_group", "genpop",
                                                     "sex", "age", "isotypes_reported", "test_type",
                                                     "specimen_type", "estimate_grade",
                                                     "subgroup_var", "subgroup_cat"])),


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

Adding `subgroup_var`, `subgroup_cat`, and `genpop` as valid filter options for the `data_provider/records` endpoint for research purposes 

## Please link the Airtable ticket associated with this PR.

None

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Little testing beside code checks passing - not clear what would be necessary to actually test this functionality! 

## Does any infrastructure work need to be done before this PR can be pushed to production?

Shouldn't be required -- modifications to existing code 
