### PR TITLE
Use SQLAlchemy instead of python to aggregate records

### DIFF
--- a/app/namespaces/data_provider/data_provider_service.py
+++ b/app/namespaces/data_provider/data_provider_service.py
@@ -4,37 +4,7 @@ import math
 from random import uniform
 
 from app.serotracker_sqlalchemy import db_session, DashboardSource, Country, db_model_config, dashboard_source_cols
-from sqlalchemy import case, and_
-
-
-def _get_isotype_col_expression():
-    expression = case(
-                [
-                    (and_(DashboardSource.isotype_igg == 'true',
-                          DashboardSource.isotype_igm == 'true',
-                          DashboardSource.isotype_iga == 'true'), 'IgG, IgM, IgA'),
-                    (and_(DashboardSource.isotype_igg == 'true',
-                          DashboardSource.isotype_igm == 'false',
-                          DashboardSource.isotype_iga == 'true'), 'IgG, IgA'),
-                    (and_(DashboardSource.isotype_igg == 'true',
-                          DashboardSource.isotype_igm == 'true',
-                          DashboardSource.isotype_iga == 'false'), 'IgG, IgM'),
-                    (and_(DashboardSource.isotype_igg == 'false',
-                          DashboardSource.isotype_igm == 'true',
-                          DashboardSource.isotype_iga == 'true'), 'IgM, IgA'),
-                    (and_(DashboardSource.isotype_igg == 'true',
-                          DashboardSource.isotype_igm == 'false',
-                          DashboardSource.isotype_iga == 'false'), 'IgG'),
-                    (and_(DashboardSource.isotype_igg == 'false',
-                          DashboardSource.isotype_igm == 'false',
-                          DashboardSource.isotype_iga == 'true'), 'IgA'),
-                    (and_(DashboardSource.isotype_igg == 'false',
-                          DashboardSource.isotype_igm == 'true',
-                          DashboardSource.isotype_iga == 'false'), 'IgM')
-                ],
-                else_='').label("isotypes")
-    return expression
-
+from app.utils import _get_isotype_col_expression
 
 def _get_parsed_record(results):
     # Store columns that are multi select and that need to be converted to list

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -3,5 +3,5 @@ from .notifications_sender import send_api_error_slack_notif, send_slack_message
 from .cached_json_handler import write_to_json, read_from_json
 from .helper_funcs import validate_request_input_against_schema, convert_start_end_dates
 from .airtable_fields_config import airtable_fields_config, full_airtable_fields
-from .get_filtered_records import get_filtered_records, get_paginated_records
+from .get_filtered_records import get_filtered_records, get_paginated_records, _get_isotype_col_expression
 from .estimate_prioritization import get_prioritized_estimates


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

Use sqlalchemy instead of python to perform record aggregation (after joining) to increase code simplicity

## Please link the Airtable ticket associated with this PR.

N/A

## Describe the steps you took to test the feature/bugfix introduced by this PR.

-Hit endpoint locally with certain filter combinations and ensured that the same number of records were retrieved (comparing against making sql queries on my local database)
- Pointed local serotracker.com web client to local server and made sure that all functionality worked as expected

## Does any infrastructure work need to be done before this PR can be pushed to production?

- N/A