### PR TITLE
Fix EP Internal Server Errors

### DIFF
--- a/app/utils/estimate_prioritization/pooling_functions.py
+++ b/app/utils/estimate_prioritization/pooling_functions.py
@@ -11,7 +11,7 @@ PoolingFnMap = namedtuple(typename = 'PoolingFnMap',
 
 # helper function to use to generate lambdas
 def get_unique_value(series: pd.Series, default: Any = pd.NA) -> Any:
-    unique_vals = series.unique()
+    unique_vals = series.dropna().unique()
     if len(unique_vals) == 1:
         return unique_vals[0]
     else:
@@ -93,7 +93,7 @@ pooling_function_maps = [
                  column_names = ['sample_frame_info',
                                  'test_name',
                                  'subgroup_specific_category'],
-                 summary_function = lambda estimates, col: '; '.join(estimates[col].unique())),
+                 summary_function = lambda estimates, col: '; '.join(estimates[col].dropna().unique())),
     PoolingFnMap(summary_type = 'identity_from_max_denominator',
                  column_names = ['test_manufacturer',
                                  'sensitivity',


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

- Bug: internal server errors when calling /records endpoint
- Bugfix: Drop null entries in pooling function so that string concatenation won't fail

## Please link the Airtable ticket associated with this PR.

N/A

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Tested locally (using Postman) with various filter combinations (no filters, country = canada, population group = residual sera, and combinations)

## Does any infrastructure work need to be done before this PR can be pushed to production?

N/A
