### PR TITLE
Return empty DF instead of None if there are no estimates to prioritize

### DIFF
--- a/app/utils/estimate_prioritization/estimate_prioritization.py
+++ b/app/utils/estimate_prioritization/estimate_prioritization.py
@@ -54,7 +54,8 @@ def get_prioritized_estimates(estimates: pd.DataFrame,
                               pool: bool = True) -> pd.DataFrame:
     
     if estimates.empty:
-        return None 
+        # return empty DF
+        return pd.DataFrame()
     if filters is not None:
         estimates = estimates[filters]
     


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

- Internal server error when filters that return no data are given

## Please link the Airtable ticket associated with this PR.

N/A

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Locally via postman with the following filter options:

```
{
	"prioritize_estimates": true,
	"research_fields": true,
	"prioritize_estimates_mode": "analysis_dynamic",
	"include_in_srma": true,
	"filters": {
		"genpop": ["Study examining general population seroprevalence"],
		"subgroup_var": ["Race"],
		"subgroup_cat": ["Caucasian"]
	}
}
```

## Does any infrastructure work need to be done before this PR can be pushed to production?

No
