### PR TITLE
Round all floats to equal precision to ensure consistent comparisons during testadj diffing

### DIFF
--- a/app/database_etl/airtable_records_handler/airtable_records_formatter.py
+++ b/app/database_etl/airtable_records_handler/airtable_records_formatter.py
@@ -130,9 +130,7 @@ def add_test_adjustments(df: pd.DataFrame) -> pd.DataFrame:
     diff[float_cols] = diff[float_cols].astype(float)
 
     # Round float columns to a consistent number of decimal places to ensure consistent float comparisons
-    # Defines number of decimal places to round each column to
-    decimals = pd.Series([5]*len(float_cols), index=float_cols)
-    diff = diff.round(decimals)
+    diff[float_cols] = diff[float_cols].round(5)
 
     # Drop duplicates based on these cols
     duplicate_cols = ['airtable_record_id', 'test_adj', 'ind_se', 'ind_sp', 'ind_se_n', 'ind_sp_n',

--- a/app/database_etl/airtable_records_handler/airtable_records_formatter.py
+++ b/app/database_etl/airtable_records_handler/airtable_records_formatter.py
@@ -129,6 +129,11 @@ def add_test_adjustments(df: pd.DataFrame) -> pd.DataFrame:
                   'denominator_value', 'serum_pos_prevalence']
     diff[float_cols] = diff[float_cols].astype(float)
 
+    # Round float columns to a consistent number of decimal places to ensure consistent float comparisons
+    # Defines number of decimal places to round each column to
+    decimals = pd.Series([5]*len(float_cols), index=float_cols)
+    diff = diff.round(decimals)
+
     # Drop duplicates based on these cols
     duplicate_cols = ['airtable_record_id', 'test_adj', 'ind_se', 'ind_sp', 'ind_se_n', 'ind_sp_n',
                       'se_n', 'sp_n', 'sensitivity', 'specificity', 'test_validation', 'test_type', 'denominator_value',


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

Round all floats to equal precision to ensure consistent comparisons during testadj diffing

## Please link the Airtable ticket associated with this PR.

N/A

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Ran ETL locally

## Does any infrastructure work need to be done before this PR can be pushed to production?

Re-enable CI/CD
