### PR TITLE
Adding handling of edge case where there are no old records

### DIFF
--- a/app/database_etl/airtable_records_handler/airtable_records_formatter.py
+++ b/app/database_etl/airtable_records_handler/airtable_records_formatter.py
@@ -162,6 +162,10 @@ def add_test_adjustments(df: pd.DataFrame) -> pd.DataFrame:
         new_airtable_test_adj_records['adj_prev_ci_upper'] = \
             zip(*new_airtable_test_adj_records.apply(lambda x: test_adj_handler.get_adjusted_estimate(x), axis=1))
 
+    # If there are no old test adjusted records, just return the new ones
+    if old_airtable_test_adj_records.empty:
+        return new_airtable_test_adj_records
+
     # Add test adjustment data to old_test_adj_records from database
     old_airtable_record_ids = old_airtable_test_adj_records['airtable_record_id'].unique()
 


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- if there are no old records in db, should just end the test adj function early and return all new adjusted records

## Please link the Airtable ticket associated with this PR.

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does any infrastructure work need to be done before this PR can be pushed to production?
