### PR TITLE
fix get record details bug

### DIFF
--- a/app/namespaces/data_provider/data_provider_service.py
+++ b/app/namespaces/data_provider/data_provider_service.py
@@ -6,6 +6,7 @@ from random import uniform
 from app.serotracker_sqlalchemy import db_session, DashboardSource, Country, db_model_config, dashboard_source_cols
 from app.utils import _get_isotype_col_expression
 
+
 def _get_parsed_record(results):
     # Store columns that are multi select and that need to be converted to list
     multi_select_cols = db_model_config['multi_select_columns']
@@ -18,14 +19,6 @@ def _get_parsed_record(results):
         if col in multi_select_cols:
             multi_select_vals = [e for e in list(set(getattr(results_df, col).tolist())) if e is not None]
             record_details[col] = multi_select_vals
-
-        # Convert comma sep string of isotypes to list
-        elif col == 'isotypes':
-            isotypes = results_df.iloc[0][col]
-            if isotypes:
-                record_details[col] = isotypes.split(',')
-            else:
-                record_details[col] = []
 
         # Otherwise just return the single value of the column
         else:

--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -18,25 +18,25 @@ def _get_isotype_col_expression(label:str = "isotypes"):
                 [
                     (and_(DashboardSource.isotype_igg == 'true',
                           DashboardSource.isotype_igm == 'true',
-                          DashboardSource.isotype_iga == 'true'), array(['IgG, IgM, IgA'])),
+                          DashboardSource.isotype_iga == 'true'), array(["IgG", "IgM", "IgA"])),
                     (and_(DashboardSource.isotype_igg == 'true',
                           DashboardSource.isotype_igm == 'false',
-                          DashboardSource.isotype_iga == 'true'), array(['IgG, IgA'])),
+                          DashboardSource.isotype_iga == 'true'), array(["IgG", "IgA"])),
                     (and_(DashboardSource.isotype_igg == 'true',
                           DashboardSource.isotype_igm == 'true',
-                          DashboardSource.isotype_iga == 'false'), array(['IgG, IgM'])),
+                          DashboardSource.isotype_iga == 'false'), array(["IgG", "IgM"])),
                     (and_(DashboardSource.isotype_igg == 'false',
                           DashboardSource.isotype_igm == 'true',
-                          DashboardSource.isotype_iga == 'true'), array(['IgM, IgA'])),
+                          DashboardSource.isotype_iga == 'true'), array(["IgM", "IgA"])),
                     (and_(DashboardSource.isotype_igg == 'true',
                           DashboardSource.isotype_igm == 'false',
-                          DashboardSource.isotype_iga == 'false'), array(['IgG'])),
+                          DashboardSource.isotype_iga == 'false'), array(["IgG"])),
                     (and_(DashboardSource.isotype_igg == 'false',
                           DashboardSource.isotype_igm == 'false',
-                          DashboardSource.isotype_iga == 'true'), array(['IgA'])),
+                          DashboardSource.isotype_iga == 'true'), array(["IgA"])),
                     (and_(DashboardSource.isotype_igg == 'false',
                           DashboardSource.isotype_igm == 'true',
-                          DashboardSource.isotype_iga == 'false'), array(['IgM']))
+                          DashboardSource.isotype_iga == 'false'), array(["IgM"]))
                 ],
                 else_=cast(array([]), ARRAY(String))).label(label)
     return expression


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

- Bug: Get record details was returning an array of records instead of a single one. This was causing some record detail modals on the explore tab to appear buggy.
- Solution: Remove pythonic isotype string to list conversion and instead, have sqlalchemy query return an array right away

## Please link the Airtable ticket associated with this PR.

N/A

## Describe the steps you took to test the feature/bugfix introduced by this PR.

- Tested endpoints on postman
- Ran local app and performed regression testing

## Does any infrastructure work need to be done before this PR can be pushed to production?

- N/A