### PR TITLE
augment country_alternative_names.json

### DIFF
--- a/app/database_etl/location_utils/country_alternative_names.json
+++ b/app/database_etl/location_utils/country_alternative_names.json
@@ -26,5 +26,22 @@
     "EST": [
         "Republic of Estonia",
         "Estonia"
+    ],
+    "GBR": [
+        "The United Kingdom",
+        "United Kingdom"
+    ],
+    "IRN": [
+        "Iran (Islamic Republic of)",
+        "Iran"
+    ], 
+    "JEY": [
+        "Jersey"
+    ],
+    "GUF": [
+        "French Guiana"
+    ],
+    "FRO": [
+        "Faroe Islands"
     ]
 }


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

Case and test data for some countries was not being pulled because these countries had different names in our data and in the Hopkins data. Augmented the mapping in our data to fix this. 

## Please link the Airtable ticket associated with this PR.

None. However, I have added a ticket to ensure that countries with missing data are identified automatically via Slack going forward. Ticket link: https://airtable.com/tbli2lWQHAqBa6ZcI/viw8Ro4zYPYcBGXRw/recPEw7IDgiOWalqQ?blocks=hide

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Ran ETL locally. 

## Does any infrastructure work need to be done before this PR can be pushed to production?

No.