### PR TITLE
change remove to discard to prevent keyerrors

### DIFF
--- a/app/database_etl/postgres_tables_handler/table_formatter.py
+++ b/app/database_etl/postgres_tables_handler/table_formatter.py
@@ -37,7 +37,7 @@ def add_mapped_variables(df: pd.DataFrame) -> pd.DataFrame:
     # Get set of all countries that exist in df but not in gbd_mapping_country
     # See https://realpython.com/python-sets/#operators-vs-methods
     countries_with_no_mapping = set(df['country']) - set(gbd_mapping_country['Country'])
-    countries_with_no_mapping.remove(None)
+    countries_with_no_mapping.discard(None)
     if len(countries_with_no_mapping) > 0:
         body = 'No GBD region or subregion found for the following countries: '
         for country in countries_with_no_mapping:


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

When we map GBD regions, WHO regions, and other attributes to countries, we check to ensure that we have a mapping for every country. Previously, we were reporting None as a country which lacked attributes, but recently, we pushed a change to remove None options from the data. However, if there are no None options, `set.remove()` throws a `KeyError`. Substituting this with `set.discard()` fixes this.

## Please link the Airtable ticket associated with this PR.

None

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Ran ETL locally

## Does any infrastructure work need to be done before this PR can be pushed to production?

No