### PR TITLE
Add include_records_without_latlngs flag

### DIFF
--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -43,6 +43,7 @@ class Records(Resource):
         include_disputed_regions = data.get('include_disputed_regions', False)
         include_subgeography_estimates = data.get('include_subgeography_estimates', False)
         unity_aligned_only = data.get('unity_aligned_only', False)
+        include_records_without_latlngs = data.get('include_records_without_latlngs', False)
 
         sampling_start_date, sampling_end_date = convert_start_end_dates(data, use_sampling_date=True)
         publication_start_date, publication_end_date = convert_start_end_dates(data, use_sampling_date=False)
@@ -59,7 +60,8 @@ class Records(Resource):
                                       include_in_srma=include_in_srma,
                                       include_disputed_regions=include_disputed_regions,
                                       include_subgeography_estimates=include_subgeography_estimates,
-                                      unity_aligned_only=unity_aligned_only)
+                                      unity_aligned_only=unity_aligned_only,
+                                      include_records_without_latlngs=include_records_without_latlngs)
         if not columns or ("pin_latitude" in columns and "pin_longitude" in columns):
             result = jitter_pins(result)
         return jsonify(result)

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -46,6 +46,7 @@ class RecordsSchema(Schema):
     include_disputed_regions = fields.Boolean(allow_none=True)
     include_subgeography_estimates = fields.Boolean(allow_none=True)
     unity_aligned_only = fields.Boolean(allow_none=True)
+    include_records_without_latlngs = fields.Boolean(allow_none=True)
 
 
 class PaginatedRecordsSchema(RecordsSchema):

--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -142,8 +142,10 @@ Output: set of records represented by dicts
 def get_filtered_records(research_fields=False, filters=None, columns=None, include_disputed_regions=False,
                          sampling_start_date=None, sampling_end_date=None, include_subgeography_estimates=False,
                          publication_start_date=None, publication_end_date=None, prioritize_estimates=True,
-                         prioritize_estimates_mode='dashboard', include_in_srma=False, unity_aligned_only=False):
-    query_dicts = get_all_records(research_fields, include_disputed_regions, unity_aligned_only)
+                         prioritize_estimates_mode='dashboard', include_in_srma=False, unity_aligned_only=False,
+                         include_records_without_latlngs=False):
+    query_dicts = get_all_records(research_fields, include_disputed_regions, unity_aligned_only,
+                                  include_records_without_latlngs)
     if query_dicts is None or len(query_dicts) == 0:
         return []
 


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

Adds new flag to /records endpoint to allow us to query records with insufficient latlng data

## Please link the Airtable ticket associated with this PR.

N/A

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Spun up local server and tested making requests to it

## Does any infrastructure work need to be done before this PR can be pushed to production?

N/A, note that this should be merged to master before publishing changes to serosurvr @harrietware 
