### PR TITLE
Remove duplicate household and community samples from static filter options

### DIFF
--- a/app/database_etl/postgres_tables_handler/postgres_utils.py
+++ b/app/database_etl/postgres_tables_handler/postgres_utils.py
@@ -40,7 +40,6 @@ def get_filter_static_options() -> Dict[str, List[str]]:
             "Pregnant or parturient women",
             "Perinatal",
             "Patients seeking care for non-COVID-19 reasons",
-            "Household and community samples",
             "Health care workers and caregivers",
             "Family of essential workers"
         ],


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- "Household and community samples" was repeated twice in the static filter options for population group
-
## Please link the Airtable ticket associated with this PR.

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does any infrastructure work need to be done before this PR can be pushed to production?
