### PR TITLE
Add new test adj model to ETL

### DIFF
--- a/app/database_etl/airtable_records_handler/__init__.py
+++ b/app/database_etl/airtable_records_handler/__init__.py
@@ -1,3 +1,3 @@
 from .airtable_records_getter import get_all_records, ingest_sample_frame_goi_filter_options
 from .airtable_records_formatter import apply_min_risk_of_bias, apply_study_max_estimate_grade,\
-    standardize_airtable_data, add_test_adjustments
+    standardize_airtable_data

--- a/app/database_etl/airtable_records_handler/airtable_records_formatter.py
+++ b/app/database_etl/airtable_records_handler/airtable_records_formatter.py
@@ -1,12 +1,8 @@
-import multiprocessing
-
 import numpy as np
 from typing import Dict
 import pandas as pd
 
 from ..location_utils import get_city
-from app.serotracker_sqlalchemy import db_session, ResearchSource, DashboardSource
-from app.database_etl.test_adjustment_handler import TestAdjHandler
 
 
 def get_most_recent_publication_info(row: Dict) -> Dict:
@@ -71,7 +67,8 @@ def standardize_airtable_data(df: pd.DataFrame) -> pd.DataFrame:
     df.replace({'nr': None, 'NR': None, 'Not Reported': None, 'Not reported': None,
                 'Not available': None, 'NA': None}, inplace=True)
 
-    # Replace columns that should be floats with NaN from None and rescale to percentage
+    # Replace columns that should be floats with NaN from None
+    # IMPORTANT: ind_sp and ind_se are percentages but stored as ints in airtable so must convert to decimal!
     df[['ind_sp', 'ind_se']] = df[['ind_sp', 'ind_se']].replace({None: np.nan}) / 100
 
     # Get index of most recent publication date
@@ -108,108 +105,3 @@ def apply_study_max_estimate_grade(df: pd.DataFrame) -> pd.DataFrame:
                 subset['estimate_grade'] = level
                 continue
     return df
-
-
-def add_test_adjustments(df: pd.DataFrame) -> pd.DataFrame:
-    # Query record ids in our database
-    with db_session() as session:
-        total_db_records = session.query(DashboardSource.serum_pos_prevalence,
-                                         DashboardSource.test_adj,
-                                         DashboardSource.sensitivity,
-                                         DashboardSource.specificity,
-                                         DashboardSource.test_type,
-                                         DashboardSource.denominator_value,
-                                         DashboardSource.adj_prevalence,
-                                         ResearchSource.ind_se,
-                                         ResearchSource.ind_sp,
-                                         ResearchSource.ind_se_n,
-                                         ResearchSource.ind_sp_n,
-                                         ResearchSource.se_n,
-                                         ResearchSource.sp_n,
-                                         ResearchSource.test_validation,
-                                         ResearchSource.airtable_record_id) \
-            .join(ResearchSource, ResearchSource.source_id == DashboardSource.source_id, isouter=True).all()
-        total_db_records = [q._asdict() for q in total_db_records]
-        total_db_records = pd.DataFrame(data=total_db_records)
-
-    # Concat old and new records and fillna with 0 (NaN and None become 0 so it is standardized)
-    diff = pd.concat([df, total_db_records])
-    diff.fillna(0, inplace=True)
-
-    # Convert numeric cols to float (some of these come out of airtable as strings so need to standardize types)
-    float_cols = ['ind_se', 'ind_sp', 'ind_se_n', 'ind_sp_n', 'se_n', 'sp_n', 'sensitivity', 'specificity',
-                  'denominator_value', 'serum_pos_prevalence']
-    diff[float_cols] = diff[float_cols].astype(float)
-
-    # Round float columns to a consistent number of decimal places to ensure consistent float comparisons
-    diff[float_cols] = diff[float_cols].round(5)
-
-    # Drop duplicates based on these cols
-    duplicate_cols = ['airtable_record_id', 'test_adj', 'ind_se', 'ind_sp', 'ind_se_n', 'ind_sp_n',
-                      'se_n', 'sp_n', 'sensitivity', 'specificity', 'test_validation', 'test_type', 'denominator_value',
-                      'serum_pos_prevalence']
-    diff = diff.drop_duplicates(subset=duplicate_cols, keep=False)
-
-    # Get all unique airtable_record_ids that are new/have been modified
-    new_airtable_record_ids = diff['airtable_record_id'].unique()
-
-    # Add all unique airtable_record_ids for which test adjustment was unsuccessful 
-    # TODO: MUST BE COMMENTED OUT IN PROD
-    """
-    unadjusted_airtable_record_ids = total_db_records[total_db_records['adj_prevalence'].isna()]['airtable_record_id'].unique()
-    new_airtable_record_ids = set.union(set(new_airtable_record_ids), 
-                                        set(unadjusted_airtable_record_ids))
-    """
-    
-    # Get all rows from airtable data that need to be test adjusted, and ones that don't
-    old_airtable_test_adj_records = \
-        df[~df['airtable_record_id'].isin(new_airtable_record_ids)].reset_index(
-            drop=True)
-    new_airtable_test_adj_records = \
-        df[df['airtable_record_id'].isin(new_airtable_record_ids)].reset_index(
-            drop=True)
-    # Add temporary boolean column if record will be test adjusted or not
-    old_airtable_test_adj_records['test_adjusted_record'] = False
-    new_airtable_test_adj_records['test_adjusted_record'] = True
-
-    # Only proceed with test adjustment if there are new unadjusted records
-    if not new_airtable_test_adj_records.empty:
-        # Apply test adjustment to the new_test_adj_records and add 6 new columns
-        test_adj_handler = TestAdjHandler()
-        new_airtable_test_adj_records['adj_prevalence'], \
-        new_airtable_test_adj_records['adj_sensitivity'], \
-        new_airtable_test_adj_records['adj_specificity'], \
-        new_airtable_test_adj_records['ind_eval_type'], \
-        new_airtable_test_adj_records['adj_prev_ci_lower'], \
-        new_airtable_test_adj_records['adj_prev_ci_upper'] = \
-            zip(*new_airtable_test_adj_records.apply(lambda x: test_adj_handler.get_adjusted_estimate(x), axis=1))
-
-    # If there are no old test adjusted records, just return the new ones
-    if old_airtable_test_adj_records.empty:
-        return new_airtable_test_adj_records
-
-    # Add test adjustment data to old_test_adj_records from database
-    old_airtable_record_ids = old_airtable_test_adj_records['airtable_record_id'].unique()
-
-    # Query record ids in our database
-    with db_session() as session:
-        old_db_test_adj_records = session.query(DashboardSource.adj_prevalence,
-                                                DashboardSource.adj_prev_ci_lower,
-                                                DashboardSource.adj_prev_ci_upper,
-                                                ResearchSource.adj_sensitivity,
-                                                ResearchSource.adj_specificity,
-                                                ResearchSource.ind_eval_type,
-                                                ResearchSource.airtable_record_id) \
-            .join(ResearchSource, ResearchSource.source_id == DashboardSource.source_id, isouter=True) \
-            .filter(ResearchSource.airtable_record_id.in_(old_airtable_record_ids)).all()
-        old_db_test_adj_records = [q._asdict() for q in old_db_test_adj_records]
-        old_db_test_adj_records = pd.DataFrame(data=old_db_test_adj_records)
-
-    # Join old_airtable_test_adj_records with old_db_adjusted_records
-    old_airtable_test_adj_records = \
-        old_airtable_test_adj_records.join(old_db_test_adj_records.set_index('airtable_record_id'),
-                                           on='airtable_record_id')
-
-    # Concat the old and new airtable test adj records
-    airtable_master_data = pd.concat([new_airtable_test_adj_records, old_airtable_test_adj_records])
-    return airtable_master_data

--- a/app/database_etl/etl_main.py
+++ b/app/database_etl/etl_main.py
@@ -11,7 +11,8 @@ from app.database_etl.postgres_tables_handler import create_dashboard_source_df,
     add_mapped_variables, validate_records, load_postgres_tables, drop_table_entries, check_filter_options, \
     validate_pooling_function_columns
 from app.database_etl.airtable_records_handler import get_all_records, apply_study_max_estimate_grade,\
-    apply_min_risk_of_bias, standardize_airtable_data, add_test_adjustments, ingest_sample_frame_goi_filter_options
+    apply_min_risk_of_bias, standardize_airtable_data, ingest_sample_frame_goi_filter_options
+from app.database_etl.test_adjustment_handler import add_test_adjustments
 from app.database_etl.tableau_data_connector import upload_analyze_csv
 from app.database_etl.summary_report_generator import SummaryReport
 from app.database_etl.location_utils import compute_pin_info

--- a/app/database_etl/test_adjustment_handler/__init__.py
+++ b/app/database_etl/test_adjustment_handler/__init__.py
@@ -1,2 +1,2 @@
 from .test_adjustment_constants import bastos_estimates, testadj_model_code
-from .test_adjustment import TestAdjHandler
+from .test_adjustment import add_test_adjustments

--- a/app/database_etl/test_adjustment_handler/test_adjustment.py
+++ b/app/database_etl/test_adjustment_handler/test_adjustment.py
@@ -108,14 +108,6 @@ def add_test_adjustments(df: pd.DataFrame) -> pd.DataFrame:
     # Get all unique airtable_record_ids that are new/have been modified
     new_airtable_record_ids = diff['airtable_record_id'].unique()
 
-    # Add all unique airtable_record_ids for which test adjustment was unsuccessful
-    # TODO: MUST BE COMMENTED OUT IN PROD
-    """
-    unadjusted_airtable_record_ids = total_db_records[total_db_records['adj_prevalence'].isna()]['airtable_record_id'].unique()
-    new_airtable_record_ids = set.union(set(new_airtable_record_ids), 
-                                        set(unadjusted_airtable_record_ids))
-    """
-
     # Get all rows from airtable data that need to be test adjusted, and ones that don't
     old_airtable_test_adj_records = \
         df[~df['airtable_record_id'].isin(new_airtable_record_ids)].reset_index(

--- a/app/database_etl/test_adjustment_handler/test_adjustment.py
+++ b/app/database_etl/test_adjustment_handler/test_adjustment.py
@@ -1,20 +1,16 @@
 # monte-carlo version of RG estimator,
 # accounting for uncertainty in se and sp estimates
-import pickle
 from math import log
-from hashlib import md5
-from typing import Dict, Tuple, Union
 
 import pandas as pd
-import pystan
-import arviz
-from statsmodels.stats.proportion import proportion_confint
 from marshmallow import Schema, fields, ValidationError
 
-from app.database_etl.test_adjustment_handler import bastos_estimates, testadj_model_code
+from app.database_etl.test_adjustment_handler import testadj_model_code
+from app.namespaces.test_adjustment import TestAdjHandler
+from app.serotracker_sqlalchemy import db_session, ResearchSource, DashboardSource
 
 
-def logit(p, tol = 1e-3):
+def logit(p, tol=1e-3):
     # logit function; well defined for p in open interval (0,1)
     
     # constrain the probability to the range [tol, 1-tol]
@@ -58,209 +54,6 @@ class ModelParamsSchema(Schema):
     y_sp = fields.Float()
 
 
-class TestAdjHandler:
-    def __init__(self, model_code=testadj_model_code, model_name='testadj_binomial_se_sp',
-                 execution_params={}):
-        self.TESTADJ_MODEL = self.get_stan_model_cache(model_code=model_code, model_name=model_name)
-        self.TESTADJ_MODEL_NAME = model_name
-        # Parse execution params
-        self.n_iter = execution_params.get('n_iter', 2000)
-        self.n_chains = execution_params.get('n_chains', 4)
-        self.return_fit = execution_params.get('return_fit', False)
-        self.n_replicates = execution_params.get('n_replicates', 5)
-        self.trials_lim = execution_params.get('trials_lim', 100)
-        self.modelsets_lim = execution_params.get('modelsets_lim', 3)
-
-    # make sure to gitignore model caches, because the model needs to be compiled separately
-    # on each machine - it is system-specific C++ code
-    def get_stan_model_cache(self, model_code: str, model_name: str = 'anon_model', **kwargs: Dict) -> pystan.StanModel:
-        """Use just as you would `pystan.StanModel`"""
-
-        # Create filepath of cached model
-        code_hash = md5(model_code.encode('ascii')).hexdigest()
-        cache_fn = f'stanmodelcache-{model_name}-{code_hash}.pkl'
-
-        # Try to load cached model
-        try:
-            cached_model = pickle.load(open(cache_fn, 'rb'))
-            print(f"Using cached StanModel at filepath {cache_fn}")
-
-        # Otherwise create the model and cache it
-        except FileNotFoundError:
-            cached_model = pystan.StanModel(model_code=model_code, model_name=model_name, **kwargs)
-            with open(cache_fn, 'wb') as f:
-                pickle.dump(cached_model, f)
-        return cached_model
-
-    def fit_one_pystan_model(self, model_params: Dict) -> Tuple:
-        fit = self.TESTADJ_MODEL.sampling(data=model_params,
-                                          iter=self.n_iter,
-                                          chains=self.n_chains,
-                                          control={'adapt_delta': 0.95},
-                                          check_hmc_diagnostics=False)
-
-        summary = fit.summary()
-        summary_df = pd.DataFrame(data=summary['summary'],
-                                  index=summary['summary_rownames'],
-                                  columns=summary['summary_colnames'])
-
-        samples = fit.extract(pars='prev', permuted=True)['prev']
-
-        summary_df_parsed = summary_df.loc['prev', ['50%', '2.5%', '97.5%']]
-        summary_df_parsed['samples'] = samples
-        summary_df_parsed['fit'] = fit
-
-        diagnostics = pystan.diagnostics.check_hmc_diagnostics(fit)
-
-        satisfactory_model_found = all(diagnostics.values())
-        return summary_df_parsed, satisfactory_model_found
-
-    def pystan_adjust(self, model_params: Dict, execution_params: Dict = {}) -> Union[Tuple, pystan.StanModel]:
-        if self.n_replicates % 2 != 1:
-            raise ValueError(f'n_replicates must be odd')
-        credible_interval_size = execution_params.get('credible_interval_size', 0.95)
-
-        # Validate model_params using marshmallow
-        try:
-            ModelParamsSchema().load(model_params)
-        except ValidationError as err:
-            print("Error: ", err.messages)
-            return None, None, None
-
-        satisfactory_model_set_found = False
-        n_modelsets = 0
-
-        while not satisfactory_model_set_found:
-            satisfactory_model_set = []
-            for _ in range(self.n_replicates):
-                n_trials = 0
-                satisfactory_model_found = False
-
-                while not satisfactory_model_found:
-                    # Attempt to fit a model
-                    summary_df_parsed, satisfactory_model_found = self.fit_one_pystan_model(model_params)
-                    # If number of attempts exceeded, return Nones
-                    n_trials += 1
-                    if n_trials >= self.trials_lim:
-                        print('no models met the HMC diagnostics in {trials_lim} trials')
-                        return None, None, None
-
-                satisfactory_model_set.append(summary_df_parsed)
-
-            satisfactory_models_df = pd.DataFrame(satisfactory_model_set)
-
-            # see whether all results are within 10% of median; if not, rerun
-            model_medians = satisfactory_models_df['50%']
-            median = model_medians.median()
-            consistent_results_found = model_medians.between(0.9 * median, 1.1 * median).all()
-            median_run = satisfactory_models_df[satisfactory_models_df['50%'] == median].iloc[0]
-
-            lower, upper = arviz.hdi(median_run['samples'], credible_interval_size)
-            best_fit = median_run['fit']
-
-            try:
-                raw_prev = model_params['y_prev_obs'] / model_params['n_prev_obs']
-                bounded = result_is_bounded(median, raw_prev)
-            except (ZeroDivisionError, ValueError):
-                return None, None, None
-
-            satisfactory_model_set_found = consistent_results_found and bounded
-
-            n_modelsets += 1
-            if n_modelsets > self.modelsets_lim:
-                return None, None, None
-
-        if self.return_fit:
-            return best_fit
-        else:
-            return lower, median, upper
-
-    def get_adjusted_estimate(self, estimate: pd.Series) -> Tuple:
-        # initialize adj_type
-        adj_type = None
-
-        # unadjusted estimate available and thus prioritized in estimate selection code
-        if pd.isna(estimate['test_adj']):
-
-            # Independent evaluation is available
-            if pd.notna(estimate['ind_se']) and pd.notna(estimate['ind_sp']):
-                adj_type = 'FINDDx / MUHC independent evaluation'
-                # Also note these must be divided by 100
-                se = (estimate['ind_se']) / 100
-                sp = (estimate['ind_sp']) / 100
-                se_n = float(estimate['ind_se_n'][0]) * 100 if estimate['ind_se_n'] is not None else 30
-                sp_n = float(estimate['ind_sp_n'][0]) * 100 if estimate['ind_sp_n'] is not None else 80
-
-            # Author evaluation is available
-            elif pd.notna(estimate['se_n']) and pd.notna(estimate['sp_n']) and \
-                    pd.notna(estimate['sensitivity']) and pd.notna(estimate['specificity']):
-                if estimate['test_validation'] and \
-                        'Validated by independent authors/third party/non-developers' in estimate['test_validation']:
-                    adj_type = 'Author-reported independent evaluation'
-                else:
-                    adj_type = 'Test developer / manufacturer evaluation'
-                se = estimate['sensitivity']
-                sp = estimate['specificity']
-                se_n = estimate['se_n'] if pd.notna(estimate['se_n']) else 30
-                sp_n = estimate['sp_n'] if pd.notna(estimate['sp_n']) else 80
-
-            # Manufacturer evaluation is available
-            elif pd.notna(estimate['sensitivity']) and pd.notna(estimate['specificity']):
-                adj_type = 'Test developer / manufacturer evaluation'
-                se = estimate['sensitivity']
-                sp = estimate['specificity']
-                # per FDA minimum requirements https://www.fda.gov/medical-devices/
-                # coronavirus-disease-2019-covid-19-emergency-use-authorizations-medical-devices/
-                # eua-authorized-serology-test-performance
-                se_n, sp_n = 30, 80
-
-            else:
-                # if there is no matched adjusted estimate available:
-                found_test_type = False
-                for test_type in ['LFIA', 'CLIA', 'ELISA']:
-                    if estimate['test_type'] and test_type == estimate['test_type']:
-                        se = bastos_estimates[test_type]['se']['50']
-                        sp = bastos_estimates[test_type]['sp']['50']
-                        se_n = bastos_estimates[test_type]['se']['n']
-                        sp_n = bastos_estimates[test_type]['sp']['n']
-                        adj_type = 'Used Bastos SR/MA data; no sens, spec, or author adjustment available'
-                        found_test_type = True
-                        break
-                if not found_test_type:
-                    adj_type = 'No data altogether'
-
-            if adj_type == 'No data altogether':
-                adj_prev = None
-                se = None
-                sp = None
-                lower = None
-                upper = None
-            else:
-                print(f'ADJUSTING ESTIMATE AT INDEX {estimate.name}', adj_type)
-                model_params = dict(
-                    n_prev_obs=int(estimate['denominator_value']),
-                    y_prev_obs=int(
-                        estimate['serum_pos_prevalence'] * estimate['denominator_value']),
-                    n_se=int(se_n),
-                    y_se=int(se_n * se),
-                    n_sp=int(sp_n),
-                    y_sp=int(sp_n * sp)
-                )
-                lower, adj_prev, upper = self.pystan_adjust(model_params)
-                if pd.isna(adj_prev):
-                    print(f'FAILED TO ADJUST ESTIMATE AT INDEX {estimate.name}')
-
-        else:
-            adj_type = 'Used author-adjusted estimate'
-            adj_prev = estimate['serum_pos_prevalence']
-            se = estimate['sensitivity']
-            sp = estimate['specificity']
-
-            lower, upper = proportion_confint(int(estimate['denominator_value'] * estimate['serum_pos_prevalence']),
-                                              estimate['denominator_value'], alpha=0.05, method='jeffreys')
-        return adj_prev, se, sp, adj_type, lower, upper
-
-
 def run_on_test_set(model_code: str = testadj_model_code, model_name: str = 'testadj_binomial_se_sp') -> pd.DataFrame:
     records_df = pd.read_csv('test_adj_test_set.csv')
     testadjHandler = TestAdjHandler(model_code=model_code, model_name=model_name)
@@ -270,3 +63,122 @@ def run_on_test_set(model_code: str = testadj_model_code, model_name: str = 'tes
     records_df['ind_eval_type'], records_df['adj_prev_ci_lower'], records_df['adj_prev_ci_upper'] = \
         zip(*records_df.apply(lambda row: testadjHandler.get_adjusted_estimate(row), axis=1))
     return records_df
+
+
+def add_test_adjustments(df: pd.DataFrame) -> pd.DataFrame:
+    # Query record ids in our database
+    with db_session() as session:
+        total_db_records = session.query(DashboardSource.serum_pos_prevalence,
+                                         DashboardSource.test_adj,
+                                         DashboardSource.sensitivity,
+                                         DashboardSource.specificity,
+                                         DashboardSource.test_type,
+                                         DashboardSource.denominator_value,
+                                         DashboardSource.adj_prevalence,
+                                         ResearchSource.ind_se,
+                                         ResearchSource.ind_sp,
+                                         ResearchSource.ind_se_n,
+                                         ResearchSource.ind_sp_n,
+                                         ResearchSource.se_n,
+                                         ResearchSource.sp_n,
+                                         ResearchSource.test_validation,
+                                         ResearchSource.airtable_record_id) \
+            .join(ResearchSource, ResearchSource.source_id == DashboardSource.source_id, isouter=True).all()
+        total_db_records = [q._asdict() for q in total_db_records]
+        total_db_records = pd.DataFrame(data=total_db_records)
+
+    # Concat old and new records and fillna with 0 (NaN and None become 0 so it is standardized)
+    diff = pd.concat([df, total_db_records])
+    diff.fillna(0, inplace=True)
+
+    # Convert numeric cols to float (some of these come out of airtable as strings so need to standardize types)
+    float_cols = ['ind_se', 'ind_sp', 'ind_se_n', 'ind_sp_n', 'se_n', 'sp_n', 'sensitivity', 'specificity',
+                  'denominator_value', 'serum_pos_prevalence']
+    diff[float_cols] = diff[float_cols].astype(float)
+
+    # Round float columns to a consistent number of decimal places to ensure consistent float comparisons
+    diff[float_cols] = diff[float_cols].round(5)
+
+    # Drop duplicates based on these cols
+    duplicate_cols = ['airtable_record_id', 'test_adj', 'ind_se', 'ind_sp', 'ind_se_n', 'ind_sp_n',
+                      'se_n', 'sp_n', 'sensitivity', 'specificity', 'test_validation', 'test_type', 'denominator_value',
+                      'serum_pos_prevalence']
+    diff = diff.drop_duplicates(subset=duplicate_cols, keep=False)
+
+    # Get all unique airtable_record_ids that are new/have been modified
+    new_airtable_record_ids = diff['airtable_record_id'].unique()
+
+    # Add all unique airtable_record_ids for which test adjustment was unsuccessful
+    # TODO: MUST BE COMMENTED OUT IN PROD
+    """
+    unadjusted_airtable_record_ids = total_db_records[total_db_records['adj_prevalence'].isna()]['airtable_record_id'].unique()
+    new_airtable_record_ids = set.union(set(new_airtable_record_ids), 
+                                        set(unadjusted_airtable_record_ids))
+    """
+
+    # Get all rows from airtable data that need to be test adjusted, and ones that don't
+    old_airtable_test_adj_records = \
+        df[~df['airtable_record_id'].isin(new_airtable_record_ids)].reset_index(
+            drop=True)
+    new_airtable_test_adj_records = \
+        df[df['airtable_record_id'].isin(new_airtable_record_ids)].reset_index(
+            drop=True)
+    # Add temporary boolean column if record will be test adjusted or not
+    old_airtable_test_adj_records['test_adjusted_record'] = False
+    new_airtable_test_adj_records['test_adjusted_record'] = True
+
+    # Only proceed with test adjustment if there are new unadjusted records
+    if not new_airtable_test_adj_records.empty:
+        # Apply test adjustment to the new_test_adj_records and add 6 new columns
+        test_adj_handler = TestAdjHandler()
+        new_airtable_test_adj_records['adj_prevalence'], \
+        new_airtable_test_adj_records['adj_sensitivity'], \
+        new_airtable_test_adj_records['adj_specificity'], \
+        new_airtable_test_adj_records['ind_eval_type'], \
+        new_airtable_test_adj_records['adj_prev_ci_lower'], \
+        new_airtable_test_adj_records['adj_prev_ci_upper'] = \
+            zip(*new_airtable_test_adj_records.apply(
+                lambda x: test_adj_handler.get_adjusted_estimate(test_adj=x['test_adj'],
+                                                                 ind_se=x['ind_se'],
+                                                                 ind_sp=x['ind_sp'],
+                                                                 ind_se_n=x['ind_se_n'],
+                                                                 ind_sp_n=x['ind_sp_n'],
+                                                                 se_n=x['se_n'],
+                                                                 sp_n=x['sp_n'],
+                                                                 sensitivity=x['sensitivity'],
+                                                                 specificity=x['specificity'],
+                                                                 test_validation=x['test_validation'],
+                                                                 test_type=x['test_type'],
+                                                                 denominator_value=x['denominator_value'],
+                                                                 serum_pos_prevalence=x['serum_pos_prevalence']),
+                axis=1))
+
+    # If there are no old test adjusted records, just return the new ones
+    if old_airtable_test_adj_records.empty:
+        return new_airtable_test_adj_records
+
+    # Add test adjustment data to old_test_adj_records from database
+    old_airtable_record_ids = old_airtable_test_adj_records['airtable_record_id'].unique()
+
+    # Query record ids in our database
+    with db_session() as session:
+        old_db_test_adj_records = session.query(DashboardSource.adj_prevalence,
+                                                DashboardSource.adj_prev_ci_lower,
+                                                DashboardSource.adj_prev_ci_upper,
+                                                ResearchSource.adj_sensitivity,
+                                                ResearchSource.adj_specificity,
+                                                ResearchSource.ind_eval_type,
+                                                ResearchSource.airtable_record_id) \
+            .join(ResearchSource, ResearchSource.source_id == DashboardSource.source_id, isouter=True) \
+            .filter(ResearchSource.airtable_record_id.in_(old_airtable_record_ids)).all()
+        old_db_test_adj_records = [q._asdict() for q in old_db_test_adj_records]
+        old_db_test_adj_records = pd.DataFrame(data=old_db_test_adj_records)
+
+    # Join old_airtable_test_adj_records with old_db_adjusted_records
+    old_airtable_test_adj_records = \
+        old_airtable_test_adj_records.join(old_db_test_adj_records.set_index('airtable_record_id'),
+                                           on='airtable_record_id')
+
+    # Concat the old and new airtable test adj records
+    airtable_master_data = pd.concat([new_airtable_test_adj_records, old_airtable_test_adj_records])
+    return airtable_master_data

--- a/app/namespaces/test_adjustment/__init__.py
+++ b/app/namespaces/test_adjustment/__init__.py
@@ -1,1 +1,2 @@
 from .test_adjustment_controller import test_adjustment_ns
+from .test_adjustment_service import TestAdjHandler

--- a/app/namespaces/test_adjustment/test_adjustment_schema.py
+++ b/app/namespaces/test_adjustment/test_adjustment_schema.py
@@ -3,12 +3,14 @@ from marshmallow import Schema, fields
 
 class TestAdjustmentSchema(Schema):
     test_adj = fields.Boolean(allow_none=True)
+    # ind_se and ind_sp are percentages; and must have values between 0.005
     ind_se = fields.Float(allow_none=True)
     ind_sp = fields.Float(allow_none=True)
     ind_se_n = fields.Integer(allow_none=True)
     ind_sp_n = fields.Integer(allow_none=True)
     se_n = fields.Integer(allow_none=True)
     sp_n = fields.Integer(allow_none=True)
+    # sensitivity and specificity are percentages; and must have values between 0.005
     sensitivity = fields.Float(allow_none=True)
     specificity = fields.Float(allow_none=True)
     test_validation = fields.String(allow_none=True)

--- a/app/namespaces/test_adjustment/test_adjustment_schema.py
+++ b/app/namespaces/test_adjustment/test_adjustment_schema.py
@@ -3,14 +3,14 @@ from marshmallow import Schema, fields
 
 class TestAdjustmentSchema(Schema):
     test_adj = fields.Boolean(allow_none=True)
-    # ind_se and ind_sp are percentages; and must have values between 0.005
+    # ind_se and ind_sp are percentages; and must have values between 0.005 and 1
     ind_se = fields.Float(allow_none=True)
     ind_sp = fields.Float(allow_none=True)
     ind_se_n = fields.Integer(allow_none=True)
     ind_sp_n = fields.Integer(allow_none=True)
     se_n = fields.Integer(allow_none=True)
     sp_n = fields.Integer(allow_none=True)
-    # sensitivity and specificity are percentages; and must have values between 0.005
+    # sensitivity and specificity are percentages; and must have values between 0.005 and 1
     sensitivity = fields.Float(allow_none=True)
     specificity = fields.Float(allow_none=True)
     test_validation = fields.String(allow_none=True)

--- a/app/namespaces/test_adjustment/test_adjustment_service.py
+++ b/app/namespaces/test_adjustment/test_adjustment_service.py
@@ -1,5 +1,7 @@
 # monte-carlo version of RG estimator,
 # accounting for uncertainty in se and sp estimates
+import logging
+import os
 import pickle
 from math import log
 from hashlib import md5
@@ -36,7 +38,6 @@ def result_is_bounded(median_adj_prev, raw_prev):
     # or if both are > 0.5
     both_below_maxsmall = (median_adj_prev <= 0.5) and (raw_prev <= 0.5)
     both_above_minbig = (median_adj_prev >= 0.5) and (raw_prev >= 0.5)
-
     return (adjusted_closeto_raw or both_below_maxsmall or both_above_minbig)
 
 
@@ -73,19 +74,26 @@ class TestAdjHandler:
     def get_stan_model_cache(self, model_code: str, model_name: str = 'anon_model', **kwargs: Dict) -> pystan.StanModel:
         """Use just as you would `pystan.StanModel`"""
 
-        # Create filepath of cached model
+        # Get working directory and extract system path of iit-backend from it
+        abs_filepath_curr_dir = os.getcwd()
+        proj_root_abs_path = abs_filepath_curr_dir.split("iit-backend")[0]
+
+        # Create model absolute path
         code_hash = md5(model_code.encode('ascii')).hexdigest()
-        cache_fn = f'app/namespaces/test_adjustment/stanmodelcache-{model_name}-{code_hash}.pkl'
+        cache_fn = f'{proj_root_abs_path}iit-backend/app/namespaces/test_adjustment/stanmodelcache-{model_name}-{code_hash}.pkl'
+
+        # Get relative path of model cache (necessary because funtion will be called from different files)
+        rel_path = os.path.relpath(cache_fn, abs_filepath_curr_dir)
 
         # Try to load cached model
         try:
-            cached_model = pickle.load(open(cache_fn, 'rb'))
+            cached_model = pickle.load(open(rel_path, 'rb'))
             print(f"Using cached StanModel at filepath {cache_fn}")
 
         # Otherwise create the model and cache it
         except FileNotFoundError:
             cached_model = pystan.StanModel(model_code=model_code, model_name=model_name, **kwargs)
-            with open(cache_fn, 'wb') as f:
+            with open(rel_path, 'wb') as f:
                 pickle.dump(cached_model, f)
         return cached_model
 
@@ -111,8 +119,7 @@ class TestAdjHandler:
                                           iter=self.n_iter,
                                           chains=self.n_chains,
                                           control={'adapt_delta': adapt_delta},
-                                          check_hmc_diagnostics=False,
-                                          init=init)
+                                          check_hmc_diagnostics=False)
 
         summary = fit.summary()
         summary_df = pd.DataFrame(data=summary['summary'],
@@ -154,9 +161,9 @@ class TestAdjHandler:
             summary_df_parsed, hmc_diagnostics_passed = self.fit_one_pystan_model(model_params)
 
             # get model result
-            model_result = summary_df_parsed
-            lower, upper = arviz.hdi(model_result['samples'], credible_interval_size)
-            best_fit = model_result['fit']
+            model_result = summary_df_parsed['50%']
+            lower, upper = arviz.hdi(summary_df_parsed['samples'], credible_interval_size)
+            best_fit = summary_df_parsed['fit']
 
             try:
                 raw_prev = model_params['y_prev_obs'] / model_params['n_prev_obs']
@@ -185,8 +192,8 @@ class TestAdjHandler:
                 adj_type = 'FINDDx / MUHC independent evaluation'
                 se = ind_se
                 sp = ind_sp
-                output_se_n = float(ind_se_n) * 100 if ind_se_n is not None else 30
-                output_sp_n = float(ind_sp_n) * 100 if ind_sp_n is not None else 80
+                output_se_n = float(ind_se_n) if ind_se_n is not None else 30
+                output_sp_n = float(ind_sp_n) if ind_sp_n is not None else 80
 
             # Author evaluation is available
             elif pd.notna(se_n) and pd.notna(sp_n) and \
@@ -233,19 +240,32 @@ class TestAdjHandler:
                 upper = None
             else:
                 print('ADJUSTING ESTIMATE', adj_type)
-                model_params = dict(
-                    n_prev_obs=int(denominator_value),
-                    y_prev_obs=int(
-                        serum_pos_prevalence * denominator_value),
-                    n_se=int(output_se_n),
-                    y_se=int(output_se_n * se),
-                    n_sp=int(output_sp_n),
-                    y_sp=int(output_sp_n * sp)
-                )
-                lower, adj_prev, upper = self.pystan_adjust(model_params)
-                if pd.isna(adj_prev):
-                    print(f'FAILED TO ADJUST ESTIMATE')
-
+                # Check bounds of se, se_n, sp, sp_n
+                if se and not (se <= 1 and se >= 0.005):
+                    logging.error("se is not between 0.005 and 1")
+                    lower, adj_prev, upper = None, None, None
+                elif sp and not (sp <= 1 and sp >= 0.005):
+                    logging.error("sp is not between 0.005 and 1")
+                    lower, adj_prev, upper = None, None, None
+                elif output_se_n and output_se_n <= 1:
+                    logging.error("se_n is not between 1 and 100")
+                    lower, adj_prev, upper = None, None, None
+                elif output_sp_n and output_sp_n <= 1:
+                    logging.error("sp_n is not between 1 and 100")
+                    lower, adj_prev, upper = None, None, None
+                else:
+                    model_params = dict(
+                        n_prev_obs=int(denominator_value),
+                        y_prev_obs=int(
+                            serum_pos_prevalence * denominator_value),
+                        n_se=int(output_se_n),
+                        y_se=int(output_se_n * se),
+                        n_sp=int(output_sp_n),
+                        y_sp=int(output_sp_n * sp)
+                    )
+                    lower, adj_prev, upper = self.pystan_adjust(model_params)
+                    if pd.isna(adj_prev):
+                        print(f'FAILED TO ADJUST ESTIMATE')
         else:
             adj_type = 'Used author-adjusted estimate'
             adj_prev = serum_pos_prevalence


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- Some updates to the test adj model and sanity checks to make sure certain params are bounded correctly
- Making ETL use new test adj model that is being used by endpoint
- Moved the function in the ETL that applies diffing logic and runs test adj to the test adj folder in ETL (makes more sense to have it here)

## Please link the Airtable ticket associated with this PR.
https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viwDpHWCgFagItSc6/recyBq9zzIAb2kAVb?blocks=hide

## Describe the steps you took to test the feature/bugfix introduced by this PR.
- Ran the ETL locally for 48 estimates, sanity checked outputs

## Does any infrastructure work need to be done before this PR can be pushed to production?
- Once this PR is approved, will need to run ETL on ALL estimates in prod
