### PR TITLE
Adding in None as option for multi select tables

### DIFF
--- a/app/database_etl/etl_main.py
+++ b/app/database_etl/etl_main.py
@@ -100,13 +100,13 @@ def main():
 
         # remove state names from city name column and place them in their own column
         multi_select_tables_dict["city"]["state_name"] = multi_select_tables_dict["city"]["city_name"] \
-            .map(lambda a: a.split(",")[1] if "," in a else None)
+            .map(lambda a: a if pd.isna(a) else (a.split(",")[1] if "," in a else None))
         multi_select_tables_dict["city"]["city_name"] = multi_select_tables_dict["city"]["city_name"] \
-            .map(lambda a: a.split(",")[0] if "," in a else a)
+            .map(lambda a: a if pd.isna(a) else (a.split(",")[0] if "," in a else a))
         # do the same for the dashboard source column
         # Also standardize so the column type is always a list (None --> empty list)
         dashboard_source["city"] = dashboard_source["city"] \
-            .map(lambda cities: [city.split(",")[0] for city in cities] if cities else [])
+            .map(lambda cities: [city if pd.isna(city) else city.split(",")[0] for city in cities] if cities else [])
         dashboard_source["state"] = dashboard_source["state"] \
             .map(lambda states: states if states else [])
 

--- a/app/namespaces/data_provider/data_provider_service.py
+++ b/app/namespaces/data_provider/data_provider_service.py
@@ -199,7 +199,8 @@ def get_all_filter_options() -> Dict[str, Any]:
         results = [q[0] for q in query if q[0] is not None]
         options["city"] = sorted(results)
 
-        # Get antibody target
+        # Only surface Spike and Nucleocapsid anitbody target options because only options that are relevant for
+        # interpreting seroprev data in the context of vaccines
         query = session.query(distinct(AntibodyTarget.antibody_target_name))
         results = [q[0] for q in query if q[0] is not None and q[0] in ['Spike', 'Nucleocapsid (N-protein)']]
         options["antibody_target"] = sorted(results)

--- a/app/namespaces/data_provider/data_provider_service.py
+++ b/app/namespaces/data_provider/data_provider_service.py
@@ -201,7 +201,7 @@ def get_all_filter_options() -> Dict[str, Any]:
 
         # Get antibody target
         query = session.query(distinct(AntibodyTarget.antibody_target_name))
-        results = [q[0] for q in query if q[0] is not None]
+        results = [q[0] for q in query if q[0] is not None and q[0] in ['Spike', 'Nucleocapsid (N-protein)']]
         options["antibody_target"] = sorted(results)
 
         options["max_sampling_end_date"] = session.query(func.max(DashboardSource.sampling_end_date))[0][0].isoformat()


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- PR adds in functionality to preserve "None" as an option in multi select tables (city, state, test manufacturer, antibody target_
- Also changing filter options to only return Spike and Nucleocapsid for antibody target as request by @rahularoradfs 
## Please link the Airtable ticket associated with this PR.

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does any infrastructure work need to be done before this PR can be pushed to production?
