### PR TITLE
Setting estimate prio bool to false

### DIFF
--- a/app/database_etl/tableau_data_connector/table_generator.py
+++ b/app/database_etl/tableau_data_connector/table_generator.py
@@ -12,11 +12,11 @@ load_dotenv()
 
 def upload_analyze_csv(canadian_data):
     # Get records
-    prioritize_estimates = True if canadian_data else False
+    estimates_subgroup = 'estimate_prioritization' if canadian_data else 'all'
     include_subgeography_estimates = True if canadian_data else False
     filters = {'country': ['Canada']} if canadian_data else None
     records = get_filtered_records(research_fields=True, filters=filters, columns=None, sampling_start_date=None,
-                                   sampling_end_date=None, prioritize_estimates=prioritize_estimates,
+                                   sampling_end_date=None, estimates_subgroup=estimates_subgroup,
                                    include_subgeography_estimates=include_subgeography_estimates)
     records = jitter_pins(records)
     records_df = pd.DataFrame(records)

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -40,7 +40,7 @@ class Records(Resource):
 
         columns_requested = data.get('columns')
         research_fields = data.get('research_fields')
-        estimates_subgroup = data.get('estimates_subgroup', 'all')
+        estimates_subgroup = data.get('estimates_subgroup', 'all_estimates')
         prioritize_estimates_mode = data.get('prioritize_estimates_mode', 'dashboard')
         include_disputed_regions = data.get('include_disputed_regions', False)
         include_subgeography_estimates = data.get('include_subgeography_estimates', False)
@@ -122,7 +122,7 @@ class PaginatedRecords(Resource):
         reverse = data.get('reverse', None)
         columns = data.get('columns')
         research_fields = data.get('research_fields')
-        estimates_subgroup = data.get('estimates_subgroup', 'all')
+        estimates_subgroup = data.get('estimates_subgroup', 'all_estimates')
         prioritize_estimates_mode = data.get('prioritize_estimates_mode', 'dashboard')
         sampling_start_date, sampling_end_date = convert_start_end_dates(data, use_sampling_date=True)
         include_in_srma = data.get('include_in_srma', False)

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -122,14 +122,15 @@ class PaginatedRecords(Resource):
         reverse = data.get('reverse', None)
         columns = data.get('columns')
         research_fields = data.get('research_fields')
-        prioritize_estimates = data.get('prioritize_estimates', True)
+        estimates_subgroup = data.get('estimates_subgroup', 'all')
         prioritize_estimates_mode = data.get('prioritize_estimates_mode', 'dashboard')
         sampling_start_date, sampling_end_date = convert_start_end_dates(data, use_sampling_date=True)
         include_in_srma = data.get('include_in_srma', False)
 
-        result = get_filtered_records(research_fields, filters, columns, sampling_start_date=sampling_start_date,
+        result = get_filtered_records(research_fields, filters, columns,
+                                      sampling_start_date=sampling_start_date,
                                       sampling_end_date=sampling_end_date,
-                                      prioritize_estimates=prioritize_estimates,
+                                      estimates_subgroup=estimates_subgroup,
                                       prioritize_estimates_mode=prioritize_estimates_mode,
                                       include_in_srma=include_in_srma)
         if not columns or ("pin_latitude" in columns and "pin_longitude" in columns):

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -98,7 +98,7 @@ class Records(Resource):
 
         columns_requested = data.get('columns')
         research_fields = data.get('research_fields')
-        prioritize_estimates = data.get('prioritize_estimates', True)
+        prioritize_estimates = data.get('prioritize_estimates', False)
         prioritize_estimates_mode = data.get('prioritize_estimates_mode', 'dashboard')
         include_disputed_regions = data.get('include_disputed_regions', False)
         include_subgeography_estimates = data.get('include_subgeography_estimates', False)

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -3,9 +3,11 @@ import logging.config
 from flask_restplus import Resource, Namespace
 from flask import jsonify, make_response, request
 
-from .data_provider_service import get_record_details, get_country_seroprev_summaries, jitter_pins, get_all_filter_options
+from .data_provider_service import get_record_details, get_country_seroprev_summaries, jitter_pins, \
+    get_all_filter_options
 from .data_provider_schema import RecordDetailsSchema, RecordsSchema, PaginatedRecordsSchema, StudyCountSchema
-from app.utils import validate_request_input_against_schema, get_filtered_records, get_paginated_records, convert_start_end_dates, filter_columns
+from app.utils import validate_request_input_against_schema, get_filtered_records, get_paginated_records, \
+    convert_start_end_dates, filter_columns
 
 data_provider_ns = Namespace('data_provider', description='Endpoints for getting database records.')
 logging.getLogger(__name__)
@@ -117,23 +119,23 @@ class Records(Resource):
             columns = list(set(COUNTRY_SEROPREV_SUMMARY_COLS).union(set(columns)))
 
         records = get_filtered_records(research_fields,
-                                      filters,
-                                      columns,
-                                      sampling_start_date=sampling_start_date,
-                                      sampling_end_date=sampling_end_date,
-                                      publication_start_date=publication_start_date,
-                                      publication_end_date=publication_end_date,
-                                      prioritize_estimates=prioritize_estimates,
-                                      prioritize_estimates_mode=prioritize_estimates_mode,
-                                      include_in_srma=include_in_srma,
-                                      include_disputed_regions=include_disputed_regions,
-                                      include_subgeography_estimates=include_subgeography_estimates,
-                                      unity_aligned_only=unity_aligned_only,
-                                      include_records_without_latlngs=include_records_without_latlngs)
+                                       filters,
+                                       columns,
+                                       sampling_start_date=sampling_start_date,
+                                       sampling_end_date=sampling_end_date,
+                                       publication_start_date=publication_start_date,
+                                       publication_end_date=publication_end_date,
+                                       prioritize_estimates=prioritize_estimates,
+                                       prioritize_estimates_mode=prioritize_estimates_mode,
+                                       include_in_srma=include_in_srma,
+                                       include_disputed_regions=include_disputed_regions,
+                                       include_subgeography_estimates=include_subgeography_estimates,
+                                       unity_aligned_only=unity_aligned_only,
+                                       include_records_without_latlngs=include_records_without_latlngs)
         if not columns or ("pin_latitude" in columns and "pin_longitude" in columns):
             records = jitter_pins(records)
 
-        result = { "records": records }
+        result = {"records": records}
 
         if calculate_country_seroprev_summaries:
             # Compute seroprevalence summaries per country per estimate grade level
@@ -201,7 +203,7 @@ class PaginatedRecords(Resource):
             "sorting_key": sorting_key
         }
 
-        kwargs_not_none = { k:v for k, v in kwargs.items() if v is not None }
+        kwargs_not_none = {k: v for k, v in kwargs.items() if v is not None}
 
         # Only paginate if pagination params min_page_index, max_page_index and per_page are specified (sorting_key="sampling_end_date", reverse=true, per_page=5 by default)
         result = get_paginated_records(**kwargs_not_none)

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -40,7 +40,7 @@ class Records(Resource):
 
         columns_requested = data.get('columns')
         research_fields = data.get('research_fields')
-        estimates_subgroup = data.get('estimates_subgroup', 'primary_estimates')
+        estimates_subgroup = data.get('estimates_subgroup', 'all_estimates')
         prioritize_estimates_mode = data.get('prioritize_estimates_mode', 'dashboard')
         include_disputed_regions = data.get('include_disputed_regions', False)
         include_subgeography_estimates = data.get('include_subgeography_estimates', False)

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -40,7 +40,7 @@ class Records(Resource):
 
         columns_requested = data.get('columns')
         research_fields = data.get('research_fields')
-        estimates_subgroup = data.get('estimates_subgroup', 'all_estimates')
+        estimates_subgroup = data.get('estimates_subgroup', 'primary_estimates')
         prioritize_estimates_mode = data.get('prioritize_estimates_mode', 'dashboard')
         include_disputed_regions = data.get('include_disputed_regions', False)
         include_subgeography_estimates = data.get('include_subgeography_estimates', False)

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -38,64 +38,6 @@ class Records(Resource):
             # If there was an error with the input payload, return the error and 422 response
             return make_response(payload, status_code)
 
-        columns = data.get('columns')
-        research_fields = data.get('research_fields')
-        estimates_subgroup = data.get('estimates_subgroup', 'all')
-        prioritize_estimates_mode = data.get('prioritize_estimates_mode', 'dashboard')
-        include_disputed_regions = data.get('include_disputed_regions', False)
-        include_subgeography_estimates = data.get('include_subgeography_estimates', False)
-        unity_aligned_only = data.get('unity_aligned_only', False)
-        include_records_without_latlngs = data.get('include_records_without_latlngs', False)
-
-        sampling_start_date, sampling_end_date = convert_start_end_dates(data, use_sampling_date=True)
-        publication_start_date, publication_end_date = convert_start_end_dates(data, use_sampling_date=False)
-        include_in_srma = data.get('include_in_srma', False)
-        result = get_filtered_records(research_fields,
-                                      filters,
-                                      columns,
-                                      sampling_start_date=sampling_start_date,
-                                      sampling_end_date=sampling_end_date,
-                                      publication_start_date=publication_start_date,
-                                      publication_end_date=publication_end_date,
-                                      estimates_subgroup=estimates_subgroup,
-                                      prioritize_estimates_mode=prioritize_estimates_mode,
-                                      include_in_srma=include_in_srma,
-                                      include_disputed_regions=include_disputed_regions,
-                                      include_subgeography_estimates=include_subgeography_estimates,
-                                      unity_aligned_only=unity_aligned_only,
-                                      include_records_without_latlngs=include_records_without_latlngs)
-        if not columns or ("pin_latitude" in columns and "pin_longitude" in columns):
-            result = jitter_pins(result)
-        return jsonify(result)
-
-
-# TODO: Once we can update research code to handle schema changes in this endpoint
-# update /records with the logic featured here and deprecate this endpoint
-@data_provider_ns.route('/dashboard_records', methods=['POST'])
-class Records(Resource):
-    @data_provider_ns.doc('An endpoint for getting all records from database with or without filters.')
-    def post(self):
-        # Convert input payload to json and throw error if it doesn't exist
-        data = request.get_json()
-        if not data:
-            return {"message": "No input payload provided"}, 400
-
-        # Log request info
-        logging.info("Endpoint Type: {type}, Endpoint Path: {path}, Arguments: {args}, Payload: {payload}".format(
-            type=request.environ['REQUEST_METHOD'],
-            path=request.environ['PATH_INFO'],
-            args=dict(request.args),
-            payload=data))
-
-        # All of these params can be empty, in which case, our utility functions will just return all records
-        filters = data.get('filters')
-
-        # Validate input payload
-        payload, status_code = validate_request_input_against_schema(data, RecordsSchema())
-        if status_code != 200:
-            # If there was an error with the input payload, return the error and 422 response
-            return make_response(payload, status_code)
-
         columns_requested = data.get('columns')
         research_fields = data.get('research_fields')
         estimates_subgroup = data.get('estimates_subgroup', 'all')

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -40,7 +40,7 @@ class Records(Resource):
 
         columns = data.get('columns')
         research_fields = data.get('research_fields')
-        prioritize_estimates = data.get('prioritize_estimates', True)
+        estimates_subgroup = data.get('estimates_subgroup', 'all')
         prioritize_estimates_mode = data.get('prioritize_estimates_mode', 'dashboard')
         include_disputed_regions = data.get('include_disputed_regions', False)
         include_subgeography_estimates = data.get('include_subgeography_estimates', False)
@@ -57,7 +57,7 @@ class Records(Resource):
                                       sampling_end_date=sampling_end_date,
                                       publication_start_date=publication_start_date,
                                       publication_end_date=publication_end_date,
-                                      prioritize_estimates=prioritize_estimates,
+                                      estimates_subgroup=estimates_subgroup,
                                       prioritize_estimates_mode=prioritize_estimates_mode,
                                       include_in_srma=include_in_srma,
                                       include_disputed_regions=include_disputed_regions,
@@ -98,7 +98,7 @@ class Records(Resource):
 
         columns_requested = data.get('columns')
         research_fields = data.get('research_fields')
-        prioritize_estimates = data.get('prioritize_estimates', False)
+        estimates_subgroup = data.get('estimates_subgroup', 'all')
         prioritize_estimates_mode = data.get('prioritize_estimates_mode', 'dashboard')
         include_disputed_regions = data.get('include_disputed_regions', False)
         include_subgeography_estimates = data.get('include_subgeography_estimates', False)
@@ -125,7 +125,7 @@ class Records(Resource):
                                        sampling_end_date=sampling_end_date,
                                        publication_start_date=publication_start_date,
                                        publication_end_date=publication_end_date,
-                                       prioritize_estimates=prioritize_estimates,
+                                       estimates_subgroup=estimates_subgroup,
                                        prioritize_estimates_mode=prioritize_estimates_mode,
                                        include_in_srma=include_in_srma,
                                        include_disputed_regions=include_disputed_regions,
@@ -144,7 +144,6 @@ class Records(Resource):
             # Ensure that we only return the requested columns to streamline data sent over HTTP
             if columns_requested:
                 result["records"] = filter_columns(result["records"], columns_requested)
-
         return jsonify(result)
 
 

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -10,8 +10,8 @@ class RecordsSchema(Schema):
     per_page = fields.Integer(allow_none=True)
     reverse = fields.Boolean(allow_none=True)
     research_fields = fields.Boolean(allow_none=True)
-    estimates_subgroup = fields.String(validate=validate.OneOf(['all',
-                                                                'estimate_prioritization',
+    estimates_subgroup = fields.String(validate=validate.OneOf(['all_estimates',
+                                                                'prioritize_estimates',
                                                                 'primary_estimates']), allow_none=True)
     prioritize_estimates_mode = fields.String(validate=validate.OneOf(['analysis_dynamic',
                                                                        'analysis_static',

--- a/app/namespaces/data_provider/data_provider_schema.py
+++ b/app/namespaces/data_provider/data_provider_schema.py
@@ -10,7 +10,9 @@ class RecordsSchema(Schema):
     per_page = fields.Integer(allow_none=True)
     reverse = fields.Boolean(allow_none=True)
     research_fields = fields.Boolean(allow_none=True)
-    prioritize_estimates = fields.Boolean(allow_none=True)
+    estimates_subgroup = fields.String(validate=validate.OneOf(['all',
+                                                                'estimate_prioritization',
+                                                                'primary_estimates']), allow_none=True)
     prioritize_estimates_mode = fields.String(validate=validate.OneOf(['analysis_dynamic',
                                                                        'analysis_static',
                                                                        'dashboard']), allow_none=True)

--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -131,7 +131,7 @@ def get_all_records(research_fields=False, include_disputed_regions=False,
 
 def get_filtered_records(research_fields=False, filters=None, columns=None, include_disputed_regions=False,
                          sampling_start_date=None, sampling_end_date=None, include_subgeography_estimates=False,
-                         publication_start_date=None, publication_end_date=None, prioritize_estimates=False,
+                         publication_start_date=None, publication_end_date=None, estimates_subgroup='all',
                          prioritize_estimates_mode='dashboard', include_in_srma=False, unity_aligned_only=False,
                          include_records_without_latlngs=False):
     '''
@@ -202,7 +202,7 @@ def get_filtered_records(research_fields=False, filters=None, columns=None, incl
 
     # TODO: Determine whether to update get_prioritized_estimates to work on dictionaries
     # or keep everything in dataframes (don't want to have this conversion here long term)
-    if prioritize_estimates:
+    if estimates_subgroup == 'estimate_prioritization':
         result_df = pd.DataFrame(result)
         if include_subgeography_estimates:
             prioritized_records = get_prioritized_estimates_without_pooling(result_df,
@@ -224,7 +224,7 @@ def get_filtered_records(research_fields=False, filters=None, columns=None, incl
             prioritized_records = prioritized_records.fillna(np.nan).replace({np.nan: None})
         result = prioritized_records.to_dict('records')
     # If prioritize_estimates is false, just return the primary estimate for each study
-    else:
+    elif estimates_subgroup == 'primary_estimates':
         result_df = pd.DataFrame(result)
         primary_estimates_df = result_df.loc[result_df['dashboard_primary_estimate'] == True]
         result = primary_estimates_df.to_dict('records')

--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -223,6 +223,11 @@ def get_filtered_records(research_fields=False, filters=None, columns=None, incl
             # Filling all NaN values with None: https://stackoverflow.com/questions/46283312/how-to-proceed-with-none-value-in-pandas-fillna
             prioritized_records = prioritized_records.fillna(np.nan).replace({np.nan: None})
         result = prioritized_records.to_dict('records')
+    # If prioritize_estimates is false, just return the primary estimate for each study
+    else:
+        result_df = pd.DataFrame(result)
+        primary_estimates_df = result_df.loc[result_df['dashboard_primary_estimate'] == True]
+        result = primary_estimates_df.to_dict('records')
 
     # Need to check if 'research_fields' is applied
     # because the include_in_srma field is in the ResearchSource table

--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -200,8 +200,7 @@ def get_filtered_records(research_fields=False, filters=None, columns=None, incl
             if record.get(field, None) is not None:
                 record[field] = record[field].isoformat()
 
-    # TODO: Determine whether to update get_prioritized_estimates to work on dictionaries
-    # or keep everything in dataframes (don't want to have this conversion here long term)
+    # If estimates_subgroup is 'estimate_prioritization', perform estimate prioritization
     if estimates_subgroup == 'estimate_prioritization':
         result_df = pd.DataFrame(result)
         if include_subgeography_estimates:
@@ -220,10 +219,11 @@ def get_filtered_records(research_fields=False, filters=None, columns=None, incl
                 # True/False have dtype="object" instead of "bool"
                 if True in prioritized_records[col].values:
                     prioritized_records[col] = prioritized_records[col].fillna(False)
-            # Filling all NaN values with None: https://stackoverflow.com/questions/46283312/how-to-proceed-with-none-value-in-pandas-fillna
             prioritized_records = prioritized_records.fillna(np.nan).replace({np.nan: None})
         result = prioritized_records.to_dict('records')
-    # If prioritize_estimates is false, just return the primary estimate for each study
+
+    # If estimates_subgroup is 'primary_estimates', just return the primary estimate for each study
+    # Otherwise, estimates_subgroup = 'all' so just return all estimates
     elif estimates_subgroup == 'primary_estimates':
         result_df = pd.DataFrame(result)
         primary_estimates_df = result_df.loc[result_df['dashboard_primary_estimate'] == True]


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
1. This PR removes the /dashboard_records endpoint. The only endpoint available now is the /records endpoint
2. This PR removes the 'prioritize_estimates' bool param from the endpoint
3. This PR adds a parameter called estimates_subgroup that accepts three values: 'all'_estimates, 'prioritized_estimates', and 'primary_estimates'. The parameter is 'all' by default.

--> If 'all' is specified (or the param is left blank), ALL estimates will be returned (~13K estimates, multiple estimates per study)
--> If 'estimate_prioritization' is specified, only estimates output from estimate_prioritization will be returned
--> If 'primary_estimates', only the primary estimates of each study will be returned

## Please link the Airtable ticket associated with this PR.

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does any infrastructure work need to be done before this PR can be pushed to production?
- Will need coordinate deployment with frontend with @atatmaja and will need to coordinate updating the R package with @harrietware 
