### PR TITLE
Convert np.nan to null in primary estimates df

### DIFF
--- a/app/utils/get_filtered_records.py
+++ b/app/utils/get_filtered_records.py
@@ -167,6 +167,7 @@ def get_filtered_records(research_fields=False, filters=None, columns=None, incl
     elif estimates_subgroup == 'primary_estimates':
         result_df = pd.DataFrame(query_dicts)
         primary_estimates_df = result_df.loc[result_df['dashboard_primary_estimate'] == True]
+        primary_estimates_df = primary_estimates_df.fillna(np.nan).replace({np.nan: None})
         query_dicts = primary_estimates_df.to_dict('records')
 
     result = []


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses
- when called get records with 'primary_estimates' it would return NaN for some fields instead of null
- The line to convert NaN to null was only being used in the 'prioritize_estimates' logic block, so needed to copy over to do the same for primary estimates

## Please link the Airtable ticket associated with this PR.

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does any infrastructure work need to be done before this PR can be pushed to production?
