### PR TITLE
Move from flask-restplus to flask-restx

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,7 @@ import logging.config
 import multiprocessing
 
 from flask import Flask
-from flask_restplus import Api
+from flask_restx import Api
 from flask_cors import CORS
 from .config import config_by_name
 from flask_sqlalchemy import SQLAlchemy

--- a/app/namespaces/cases_count_scraper/cases_count_scraper_controller.py
+++ b/app/namespaces/cases_count_scraper/cases_count_scraper_controller.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime
 
-from flask_restplus import Resource, Namespace
+from flask_restx import Resource, Namespace
 from flask import jsonify, current_app as app
 
 from .cases_count_scraper_service import get_all_records

--- a/app/namespaces/data_provider/data_provider_controller.py
+++ b/app/namespaces/data_provider/data_provider_controller.py
@@ -1,6 +1,6 @@
 import logging.config
 
-from flask_restplus import Resource, Namespace
+from flask_restx import Resource, Namespace
 from flask import jsonify, make_response, request
 
 from .data_provider_service import get_record_details, get_country_seroprev_summaries, jitter_pins, \

--- a/app/namespaces/healthcheck/healthcheck_controller.py
+++ b/app/namespaces/healthcheck/healthcheck_controller.py
@@ -1,5 +1,5 @@
 from flask import jsonify
-from flask_restplus import Resource, Namespace
+from flask_restx import Resource, Namespace
 
 healthcheck_ns = Namespace('healthcheck', description='A health check endpoint.')
 

--- a/app/namespaces/meta_analysis/meta_analysis_controller.py
+++ b/app/namespaces/meta_analysis/meta_analysis_controller.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask_restplus import Resource, Namespace
+from flask_restx import Resource, Namespace
 from flask import make_response, request
 
 from app.utils import validate_request_input_against_schema, get_filtered_records, convert_start_end_dates

--- a/app/namespaces/test_adjustment/test_adjustment_controller.py
+++ b/app/namespaces/test_adjustment/test_adjustment_controller.py
@@ -1,6 +1,6 @@
 import logging.config
 
-from flask_restplus import Resource, Namespace
+from flask_restx import Resource, Namespace
 from flask import jsonify, make_response, request
 
 from app.utils import validate_request_input_against_schema


### PR DESCRIPTION
flask-restplus is dead and causing errors when setting up iit-backend. Moving to flask-restx.

## Briefly describe the feature or bug that this PR addresses.
When settings up iit-backend on a new computer, flask-restplus outputs errors e.g.
    ImportError: cannot import name 'cached_property' from 'werkzeug'

## Please link the Airtable ticket associated with this PR.

## Describe the steps you took to test the feature/bugfix introduced by this PR.
The bug was found and fixed while setting up iit-backend on my computer with Harriet.

## Does any infrastructure work need to be done before this PR can be pushed to production?
None that I know of (not sure how to do most of these things).