### PR TITLE
Fix estimates csv generator script

### DIFF
--- a/app/database_etl/airtable_records_handler/airtable_records_formatter.py
+++ b/app/database_etl/airtable_records_handler/airtable_records_formatter.py
@@ -71,6 +71,10 @@ def replace_null_fields(row_val):
     if row_val == None:
         return [None]
     null_cols = ['nr', 'NR', 'Not Reported', 'Not reported', 'Not available', 'NA', 'N/A']
+
+    if type(row_val) is str:
+        row_val = row_val.split(", ")
+
     return [i if i not in null_cols else None for i in row_val]
 
 

--- a/app/database_etl/airtable_records_handler/airtable_records_formatter.py
+++ b/app/database_etl/airtable_records_handler/airtable_records_formatter.py
@@ -73,9 +73,9 @@ def replace_null_fields(row_val):
     null_cols = ['nr', 'NR', 'Not Reported', 'Not reported', 'Not available', 'NA', 'N/A']
 
     if type(row_val) is str:
-        row_val = row_val.split(", ")
-
-    return [i if i not in null_cols else None for i in row_val]
+        row_val = row_val.replace(" ", ""). split(",")
+    filtered_row = [i for i in set(row_val) - set(null_cols) if i is not None]
+    return sorted(filtered_row)
 
 
 def standardize_airtable_data(df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
estimates csv generator script was not outputing the `antibody_target` and `isotype` columns as expected (refer to ticket).
## Please link the Airtable ticket associated with this PR.
https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viwFS5nE6gepmRwVB/rechvFUuXWyx4oaGA?blocks=hide
## Describe the steps you took to test the feature/bugfix introduced by this PR.
Ran the script again and the output was now showing as expected. Updated the public repo with the new CSV manually for the time-being
## Does any infrastructure work need to be done before this PR can be pushed to production?
